### PR TITLE
fix(ci): skip GKE deploy when gcloud unavailable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
   deploy:
     name: Build & Deploy
     needs: ci
+    if: vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     env:
       REGION: europe-west3
@@ -91,6 +92,7 @@ jobs:
   smoke-test:
     name: Verify Deployment
     needs: deploy
+    if: vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     env:
       CLUSTER: clouddns-cluster


### PR DESCRIPTION
## Summary
- Add `if: vars.DEPLOY_ENABLED == 'true'` condition to `deploy` and `smoke-test` jobs
- Deployment is now silently skipped when `DEPLOY_ENABLED` variable is not set to `true`
- Re-enable by setting `DEPLOY_ENABLED=true` via `gh variable set DEPLOY_ENABLED --body=true`

## Test plan
- [ ] Push a test commit and verify deploy/smoke-test jobs show as "Skipped"
- [ ] Verify CI job still runs normally