### PR TITLE
fix(ci): make deploy workflow manual-only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy to GKE
 
 on:
-  push:
-    branches: ["main"]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -16,7 +15,6 @@ jobs:
   deploy:
     name: Build & Deploy
     needs: ci
-    if: vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     env:
       REGION: europe-west3
@@ -92,7 +90,6 @@ jobs:
   smoke-test:
     name: Verify Deployment
     needs: deploy
-    if: vars.DEPLOY_ENABLED == 'true'
     runs-on: ubuntu-latest
     env:
       CLUSTER: clouddns-cluster


### PR DESCRIPTION
## Summary
- Change trigger from `push: branches: ["main"]` to `workflow_dispatch`
- Remove the `DEPLOY_ENABLED` variable checks
- Workflow now only runs manually via GitHub UI or `gh workflow run`

## Test plan
- [ ] Verify pushing to main no longer triggers any deploy workflow jobs
- [ ] Verify manual trigger via workflow_dispatch works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified deployment workflow to require manual triggering instead of automatically deploying on code changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->