### PR TITLE
feat(core/ports): add GetDNSKEYs method to DNSRepository interface

### DIFF
--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -151,6 +151,61 @@ func (r *PostgresRepository) GetZone(ctx context.Context, name string) (*domain.
 	return &z, nil
 }
 
+func (r *PostgresRepository) GetDNSKEYs(ctx context.Context, zoneName string) ([]domain.Record, error) {
+	// First get the zone to find zone ID
+	zone, err := r.GetZone(ctx, zoneName)
+	if err != nil {
+		return nil, err
+	}
+	if zone == nil {
+		return nil, nil
+	}
+
+	query := `
+		SELECT r.id, r.zone_id, r.name, r.type, r.content, r.ttl, r.priority, r.weight, r.port, r.network,
+		       r.health_check_type, r.health_check_target, COALESCE(h.status, 'UNKNOWN')
+		FROM dns_records r
+		LEFT JOIN record_health h ON r.id = h.record_id
+		WHERE r.zone_id = $1 AND r.type = 'DNSKEY'`
+	rows, errQuery := r.db.QueryContext(ctx, query, zone.ID)
+	if errQuery != nil {
+		return nil, errQuery
+	}
+	defer func() {
+		if errClose := rows.Close(); errClose != nil {
+			log.Printf("failed to close rows: %v", errClose)
+		}
+	}()
+
+	var records []domain.Record
+	for rows.Next() {
+		var rec domain.Record
+		var priority, weight, port sql.NullInt32
+		var hcType, hcTarget, hStatus sql.NullString
+		if errScan := rows.Scan(
+			&rec.ID, &rec.ZoneID, &rec.Name, &rec.Type, &rec.Content, &rec.TTL, &priority, &weight, &port, &rec.Network,
+			&hcType, &hcTarget, &hStatus,
+		); errScan != nil {
+			return nil, errScan
+		}
+		if priority.Valid {
+			p := int(priority.Int32)
+			rec.Priority = &p
+		}
+		if weight.Valid {
+			w := int(weight.Int32)
+			rec.Weight = &w
+		}
+		if port.Valid {
+			p := int(port.Int32)
+			rec.Port = &p
+		}
+		records = append(records, rec)
+	}
+
+	return records, rows.Err()
+}
+
 func (r *PostgresRepository) GetRecord(ctx context.Context, id string, zoneID string, tenantID string) (*domain.Record, error) {
 	query := `
 		SELECT r.id, r.zone_id, r.name, r.type, r.content, r.ttl, r.priority, r.weight, r.port, r.network,

--- a/internal/adapters/repository/postgres_unit_test.go
+++ b/internal/adapters/repository/postgres_unit_test.go
@@ -219,6 +219,31 @@ func TestPostgresRepository_Unit(t *testing.T) {
 		}
 	})
 
+	// 11b. Test GetDNSKEYs
+	t.Run("GetDNSKEYs", func(t *testing.T) {
+		// First mock GetZone
+		zoneRows := sqlmock.NewRows([]string{"id", "tenant_id", "name", "vpc_id", "description", "role", "master_server", "created_at", "updated_at"}).
+			AddRow("z1", "t1", "test.com.", "", "", "master", "", time.Now(), time.Now())
+		mock.ExpectQuery(`SELECT .* FROM dns_zones WHERE LOWER\(name\) = LOWER\(\$1\)`).
+			WithArgs("test.com.").
+			WillReturnRows(zoneRows)
+
+		// Then mock GetDNSKEYs query
+		dnskeyRows := sqlmock.NewRows([]string{"id", "zone_id", "name", "type", "content", "ttl", "priority", "weight", "port", "network", "health_check_type", "health_check_target", "status"}).
+			AddRow("dk1", "z1", "test.com.", "DNSKEY", " AwAAAEEAE....", 300, nil, nil, nil, nil, nil, nil, "UNKNOWN")
+		mock.ExpectQuery(`SELECT r\.id, r\.zone_id, r\.name, r\.type, r\.content, r\.ttl, r\.priority, r\.weight, r\.port, r\.network, r\.health_check_type, r\.health_check_target, COALESCE\(h\.status, 'UNKNOWN'\) FROM dns_records r LEFT JOIN record_health h ON r\.id = h\.record_id WHERE r\.zone_id = \$1 AND r\.type = 'DNSKEY'`).
+			WithArgs("z1").
+			WillReturnRows(dnskeyRows)
+
+		recs, err := repo.GetDNSKEYs(ctx, "test.com.")
+		if err != nil {
+			t.Errorf("GetDNSKEYs failed: %v", err)
+		}
+		if len(recs) != 1 || recs[0].Type != "DNSKEY" {
+			t.Errorf("Unexpected records: %+v", recs)
+		}
+	})
+
 	// 12. Test CreateZoneWithRecords
 	t.Run("CreateZoneWithRecords", func(t *testing.T) {
 		mock.ExpectBegin()

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -40,6 +40,7 @@ type DNSRepository interface {
 	CreateKey(ctx context.Context, key *domain.DNSSECKey) error
 	ListKeysForZone(ctx context.Context, zoneID string) ([]domain.DNSSECKey, error)
 	UpdateKey(ctx context.Context, key *domain.DNSSECKey) error
+	GetDNSKEYs(ctx context.Context, zoneName string) ([]domain.Record, error)
 
 	// API Key Management
 	GetAPIKeyByHash(ctx context.Context, keyHash string) (*domain.APIKey, error)

--- a/internal/core/services/dns_service_test.go
+++ b/internal/core/services/dns_service_test.go
@@ -175,6 +175,7 @@ func (m *mockRepo) ListKeysForZone(_ context.Context, _ string) ([]domain.DNSSEC
 	return nil, m.err
 }
 func (m *mockRepo) UpdateKey(_ context.Context, _ *domain.DNSSECKey) error { return m.err }
+func (m *mockRepo) GetDNSKEYs(_ context.Context, _ string) ([]domain.Record, error) { return nil, nil }
 
 func (m *mockRepo) GetAPIKeyByHash(_ context.Context, _ string) (*domain.APIKey, error) {
 	return nil, m.err

--- a/internal/core/services/dnssec_service_test.go
+++ b/internal/core/services/dnssec_service_test.go
@@ -107,6 +107,10 @@ func (m *mockDNSSECRepo) UpdateKey(_ context.Context, key *domain.DNSSECKey) err
 	return nil
 }
 
+func (m *mockDNSSECRepo) GetDNSKEYs(_ context.Context, _ string) ([]domain.Record, error) {
+	return nil, nil
+}
+
 func (m *mockDNSSECRepo) GetAPIKeyByHash(_ context.Context, _ string) (*domain.APIKey, error) {
 	return nil, nil
 }

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -527,6 +527,18 @@ func (m *mockServerRepo) UpdateKey(ctx context.Context, key *domain.DNSSECKey) e
 	return nil
 }
 
+func (m *mockServerRepo) GetDNSKEYs(ctx context.Context, zoneName string) ([]domain.Record, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var res []domain.Record
+	for _, r := range m.records {
+		if r.Name == zoneName && r.Type == "DNSKEY" {
+			res = append(res, r)
+		}
+	}
+	return res, nil
+}
+
 func (m *mockServerRepo) Ping(ctx context.Context) error {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/testutil/mock_repo.go
+++ b/internal/testutil/mock_repo.go
@@ -154,6 +154,11 @@ func (m *MockRepo) UpdateKey(ctx context.Context, key *domain.DNSSECKey) error {
 	return args.Error(0)
 }
 
+func (m *MockRepo) GetDNSKEYs(ctx context.Context, zoneName string) ([]domain.Record, error) {
+	args := m.Called(zoneName)
+	return args.Get(0).([]domain.Record), args.Error(1)
+}
+
 func (m *MockRepo) GetAPIKeyByHash(ctx context.Context, keyHash string) (*domain.APIKey, error) {
 	args := m.Called(keyHash)
 	if args.Get(0) == nil {


### PR DESCRIPTION
## Summary
- Add `GetDNSKEYs(ctx context.Context, zoneName string) ([]domain.Record, error)` to `DNSRepository` port
- Implement in `PostgresRepository` - queries dns_records table for DNSKEY type records
- Add unit test for `GetDNSKEYs`
- Update all mock implementations to satisfy the new interface method

## Test plan
- [x] go test ./... -short
- [x] go vet ./...
- [x] go build ./...