### PR TITLE
docs: add comprehensive DNSSEC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ cloudDNS is a high-performance, authoritative, and recursive DNS server built fr
 *   **Dynamic Updates (RFC 2136)**: Secure, atomic updates to zone records at runtime.
 *   **Incremental Zone Transfer (IXFR - RFC 1995)**: Efficient replication that transfers only changes, not the entire zone.
 *   **DNS NOTIFY (RFC 1996)**: Real-time notification to secondary servers upon zone changes.
-*   **DNSSEC (RFC 4034/4035/5155)**:
-    *   **Automated Lifecycle**: Background worker handles Key (KSK/ZSK) generation and rotation.
-    *   **Double-Signature Rollover**: Zero-downtime key rotation orchestration.
+*   **DNSSEC (RFC 4033-4035/5155/8914)**:
+    *   **Signing**: Automated KSK/ZSK generation, rotation, and zone signing.
+    *   **Validation**: Response validation with AD bit and RFC 8914 Extended DNS Error (EDE) codes.
+    *   **Modes**: Disabled, ad-bit-only, or strict validation.
     *   **NSEC/NSEC3**: Authenticated denial of existence.
 *   **DNS over HTTPS (DoH - RFC 8484)**: Secure DNS queries via HTTP/2, supporting both `GET` (base64url) and `POST` (binary).
 *   **EDNS(0) & Truncation (RFC 6891)**: Extended payload support with automatic TCP fallback.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ cloudDNS is a high-performance, authoritative, and recursive DNS server built fr
 
 ## Key Features
 
+### DNSSEC (DNS Security Extensions)
+*   **Signing**: Automated KSK/ZSK generation, rotation, and zone signing with Double-Signature rollover for zero-downtime key rotation.
+*   **Validation**: Response validation with ECDSA P-256, AD bit support, and RFC 8914 Extended DNS Error (EDE) codes for debugging.
+*   **Modes**: Three validation modes - `disabled`, `ad-bit-only`, or `strict` (SERVFAIL on invalid).
+*   **NSEC/NSEC3**: Authenticated denial of existence for secure proof of non-existence.
+*   **Documentation**: See [docs/dnssec.md](docs/dnssec.md) for full details.
+
 ### Core Protocol & Performance
 *   **Manual Wire Format (RFC 1035)**: Custom binary parser and serializer for maximum control over DNS packets.
 *   **Dual-Stack Transport**: Parallel high-performance UDP listener pool and framed TCP handlers.
@@ -28,11 +35,6 @@ cloudDNS is a high-performance, authoritative, and recursive DNS server built fr
 *   **Dynamic Updates (RFC 2136)**: Secure, atomic updates to zone records at runtime.
 *   **Incremental Zone Transfer (IXFR - RFC 1995)**: Efficient replication that transfers only changes, not the entire zone.
 *   **DNS NOTIFY (RFC 1996)**: Real-time notification to secondary servers upon zone changes.
-*   **DNSSEC (RFC 4033-4035/5155/8914)**:
-    *   **Signing**: Automated KSK/ZSK generation, rotation, and zone signing.
-    *   **Validation**: Response validation with AD bit and RFC 8914 Extended DNS Error (EDE) codes.
-    *   **Modes**: Disabled, ad-bit-only, or strict validation.
-    *   **NSEC/NSEC3**: Authenticated denial of existence.
 *   **DNS over HTTPS (DoH - RFC 8484)**: Secure DNS queries via HTTP/2, supporting both `GET` (base64url) and `POST` (binary).
 *   **EDNS(0) & Truncation (RFC 6891)**: Extended payload support with automatic TCP fallback.
 *   **TSIG (RFC 2845)**: HMAC-authenticated transactions for secure updates and transfers.

--- a/docs/decisions/0008-dnssec-validation.md
+++ b/docs/decisions/0008-dnssec-validation.md
@@ -1,0 +1,192 @@
+# ADR 0008: DNSSEC Validation
+
+## Status
+Accepted
+
+## Context
+
+DNSSEC (DNS Security Extensions) adds cryptographic authentication to DNS responses, allowing validators to verify that responses originate from the authoritative DNS server and were not tampered with during transit. RFC 4033-4035 define the DNSSEC protocol.
+
+For a DNS provider to fully support DNSSEC, it must be able to:
+1. **Sign zones** (already implemented) - Sign zone data with DNSKEY/KEY records
+2. **Validate responses** (this ADR) - Verify signatures on incoming responses before returning them to clients
+
+This ADR documents the DNSSEC validation implementation for cloudDNS.
+
+## Decision
+
+We implement DNSSEC validation with the following architecture:
+
+### 1. Validation Scope (MVP)
+
+- **Algorithm**: ECDSA P-256 (Algorithm 13 / RSASHA256) - matches existing signing
+- **Denial of Existence**: NSEC only (no NSEC3 support)
+- **Trust Model**: Manual trust anchor configuration
+- **Response Bits**: Set AD (Authenticated Data) bit on validated responses
+- **Error Reporting**: RFC 8914 Extended DNS Error (EDE) codes on validation failures
+
+### 2. Component Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Server                                │
+│  ┌─────────────┐    ┌──────────────┐    ┌───────────────┐  │
+│  │ DNSSECMode  │───▶│   Validator  │───▶│  AD Bit / EDE │  │
+│  │   Config    │    │              │    │    Response   │  │
+│  └─────────────┘    └──────────────┘    └───────────────┘  │
+│                           │                                  │
+│         ┌─────────────────┼─────────────────┐               │
+│         ▼                 ▼                 ▼               │
+│  ┌────────────┐    ┌────────────┐    ┌──────────────┐      │
+│  │ Trust      │    │  Packet    │    │  Recursive   │      │
+│  │ Anchors    │    │  Verify    │    │  DNSKEY      │      │
+│  └────────────┘    └────────────┘    │  Fetch       │      │
+│                                       └──────────────┘      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 3. Key Components
+
+#### DNSSECValidator Service (`internal/core/services/dnssec_validator.go`)
+
+```go
+type DNSSECValidator struct {
+    trustAnchors map[string]packet.DNSRecord // zone -> DNSKEY
+}
+
+type ValidationResult struct {
+    Valid   bool    // Validation succeeded
+    ADBit   bool    // Set in DNS response
+    EDE     *EDE    // Extended DNS Error if invalid
+}
+```
+
+**Methods:**
+- `ValidateRRSet(rrset, rrsigs, dnskeys, now)` - Validate RRset with RRSIGs
+- `ValidateWithTrustAnchor(zone, rrset, rrsigs, dnskeys, now)` - Validate using trust anchor
+- `ValidateDNSKEYChain(dnskeys, ds, parentDNSKEY)` - Validate DNSKEY matches DS record
+- `GetTrustAnchor(zone)` - Retrieve configured trust anchor
+
+#### RFC 8914 EDE Codes
+
+Extended DNS Error codes for detailed validation failure reporting:
+
+| Code | Name | Use Case |
+|------|------|----------|
+| 0 | Other | Unclassified error |
+| 1 | UnsupportedDNSKEYAlgo | Algorithm not supported |
+| 2 | UnsupportedDSDigest | DS digest type unsupported |
+| 4 | Bogus | Signature verification failed |
+| 6 | SignatureExpired | Signature expiration passed |
+| 7 | SignatureNotYetValid | Signature not yet valid |
+| 9 | DNSKEYMissing | Matching DNSKEY not found |
+| 17 | TrustAnchorUnknown | Trust anchor not configured |
+
+#### Packet-Level Verification (`internal/dns/packet/dnssec_verify.go`)
+
+- `VerifyRRSet(rrset, rrsig, dnskey, now)` - ECDSA P-256 signature verification
+- `FindMatchingDNSKEY(rrsig, dnskeys)` - Locate correct DNSKEY for RRSIG
+- `ValidateDNSKEYFormat(dnskey)` - Verify DNSKEY wire format
+- `VerifyDNSKEYMatchesDS(dnskey, ds)` - Verify DNSKEY matches DS record
+
+### 4. DNSSEC Modes
+
+The server supports three DNSSEC validation modes:
+
+```go
+type DNSSECMode string
+const (
+    DNSSECModeDisabled    DNSSECMode = "disabled"      // No validation
+    DNSSECModeAdBitOnly  DNSSECMode = "ad-bit-only"    // Set AD on validated, no rejection
+    DNSSECModeStrict     DNSSECMode = "strict"         // Reject invalid with SERVFAIL + EDE
+)
+```
+
+### 5. Trust Anchor Configuration
+
+Trust anchors are configured manually:
+
+```yaml
+dnssec:
+  enabled: true
+  mode: strict
+  trust_anchors:
+    ".": "<root DNSKEY base64>"
+    "com.": "<com DNSKEY base64>"
+```
+
+### 6. Validation Flow
+
+```
+Client Query (DO=1)
+        │
+        ▼
+┌───────────────────┐
+│  Build Response   │
+│  (with RRSIGs)   │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│  Fetch DNSKEYs    │◀── From recursive resolution
+│  (if not cached)  │
+└────────┬──────────┘
+         │
+         ▼
+┌───────────────────┐
+│  Validate RRSet   │
+│  (signature check)│
+└────────┬──────────┘
+         │
+    ┌────┴────┐
+    │ Valid?  │
+    └────┬────┘
+    Yes  │  No
+    ┌────┴────┐
+    │         │
+    ▼         ▼
+  AD=1      [Mode]
+           Disabled: Return response (AD=0)
+           AdBitOnly: Return response (AD=0)
+           Strict: SERVFAIL + EDE
+```
+
+### 7. Implementation Timeline (PRs)
+
+| PR | Focus | Files |
+|----|-------|-------|
+| 1 | Packet-level verification | `dnssec_verify.go` |
+| 2 | Validator service | `dnssec_validator.go` |
+| 3 | Port interfaces | `ports/` |
+| 4 | Server integration | `server.go` |
+| 5 | Trust anchor config | `config/` |
+| 6 | Recursive key fetch | `recursive.go` |
+| 7 | EDE codes (RFC 8914) | `dnssec_validator.go` |
+| 8 | Integration tests | `dnssec_integration_test.go` |
+
+## Consequences
+
+### Positive
+- Clients can verify response authenticity using AD bit
+- Detailed error reporting via RFC 8914 EDE codes
+- Supports validation of any signed zone with trust anchor
+- Incremental implementation via small PRs
+
+### Negative
+- Additional latency from signature verification (ECDSA P-256 is fast)
+- Cache memory overhead for DNSKEYs
+- Complexity in recursive resolution path
+
+### Limitations (MVP)
+- No NSEC3 support (only NSEC for authenticated denial)
+- No automatic trust anchor bootstrap (manual configuration required)
+- No validation of responses from third-party resolvers
+- No ECDSA P-384 / Ed25519 support (future enhancement)
+
+## Future Enhancements
+
+1. **NSEC3 Support** - For zones using NSEC3 instead of NSEC
+2. **Automatic Trust Bootstrap** - Fetch and validate root DNSKEY automatically
+3. **Algorithm Expansion** - Add support for ECDSA P-384 and Ed25519
+4. **DS Validation** - Full chain validation from trust anchor to leaf
+5. **DNSSEC Key Rollover Support** - Handle key changes gracefully

--- a/docs/dnssec.md
+++ b/docs/dnssec.md
@@ -1,0 +1,208 @@
+# DNSSEC (DNS Security Extensions)
+
+DNSSEC adds cryptographic authentication to DNS responses, allowing resolvers to verify that responses genuinely originate from the authoritative DNS server and were not tampered with in transit.
+
+## Overview
+
+cloudDNS implements full DNSSEC support:
+
+- **Zone Signing**: Automatically sign zone data with DNSKEY/KEY records
+- **Response Validation**: Verify signatures on incoming responses before returning to clients
+- **Trust Anchors**: Manual configuration of trusted DNSKEYs
+- **AD Bit**: Set the Authenticated Data bit on validated responses
+- **EDE Codes**: RFC 8914 Extended DNS Error codes for debugging failures
+
+## How DNSSEC Works
+
+### The Problem
+
+DNS was designed for reliability, not security. An attacker can:
+- Intercept DNS queries and return false answers
+- Poison DNS caches with fraudulent records
+- Perform man-in-the-middle attacks on DNS traffic
+
+### The Solution
+
+DNSSEC adds cryptographic signatures to DNS data:
+
+```
+Traditional DNS:
+  Client ──────▶ Resolver ──────▶ Nameserver
+                ◀─────── Response (unsigned)
+
+DNSSEC:
+  Client ──────▶ Resolver ──────▶ Nameserver
+                ◀─────── Signed Response (RRSIG + DNSKEY)
+                         │
+                         ▼
+                   Signature verified!
+```
+
+### Key Concepts
+
+#### DNSKEY Records
+
+The DNSSEC signing keys. There are two types:
+
+| Type | Flag | Purpose |
+|------|------|---------|
+| **KSK** (Key Signing Key) | 257 | Signs the ZSK and is published in DS records at the parent |
+| **ZSK** (Zone Signing Key) | 256 | Signs all other records in the zone |
+
+#### RRSIG (Resource Record Signature)
+
+Cryptographic signatures for record sets. Each RRset (group of records with same name/type) has an RRSIG covering it.
+
+#### DS (Delegation Signer) Records
+
+Published by parent zones. Contains a hash of the child's KSK, establishing the trust chain from root to leaf zones.
+
+#### NSEC/NSEC3
+
+Records that prove a name or record type does not exist (authenticated denial of existence).
+
+## DNSSEC Modes
+
+cloudDNS supports three validation modes:
+
+| Mode | Description |
+|------|-------------|
+| `disabled` | No DNSSEC validation performed |
+| `ad-bit-only` | Set AD bit on validated responses; return unsigned responses normally |
+| `strict` | Return SERVFAIL + EDE for invalid signatures |
+
+### Configuration Example
+
+```yaml
+dnssec:
+  enabled: true
+  mode: strict
+  trust_anchors:
+    ".": "BSDiA8IA6XZ8xF8H5zPQIgF4S..."  # Root DNSKEY (base64)
+    "com.": "K8F+8gAIx5LZ5qJ1vL..."        # .com DNSKEY (base64)
+```
+
+## EDE (Extended DNS Errors)
+
+When DNSSEC validation fails, cloudDNS returns RFC 8914 Extended DNS Error codes to help diagnose the issue:
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 0 | Other | Unclassified error |
+| 1 | UnsupportedDNSKEYAlgo | Algorithm not supported |
+| 4 | Bogus | Signature verification failed |
+| 6 | SignatureExpired | Signature has expired |
+| 7 | SignatureNotYetValid | Signature not yet valid |
+| 9 | DNSKEYMissing | Matching DNSKEY not found |
+| 17 | TrustAnchorUnknown | Trust anchor not configured |
+
+### Example: dig Output with EDE
+
+```
+;; EDNS: version: 0, flags:; udp: 4096
+;; EDE: 6 : signature-expired
+```
+
+## Supported Algorithms
+
+cloudDNS DNSSEC implementation supports:
+
+| Algorithm | Name | Status |
+|-----------|------|--------|
+| 13 | ECDSAP256SHA256 | ✅ Fully supported (MVP) |
+| 8 | RSASHA256 | Signing only |
+| 15 | ECDSAP384SHA384 | Future |
+| 14 | ED25519 | Future |
+
+## Limitations (v1.0 MVP)
+
+- **NSEC only**: No NSEC3 support (NSEC is used for authenticated denial)
+- **Manual trust anchors**: No automatic trust anchor bootstrap from root
+- **Single algorithm**: ECDSA P-256 for validation (signing supports more)
+- **No chain validation**: Validates against trust anchor but doesn't verify full chain to root
+
+## DNSSEC in the Resolution Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Client Query                             │
+│                   (with DO flag = 1)                         │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   Resolution Engine                           │
+│              (recursive resolution + DNSSEC)                 │
+└─────────────────────────┬───────────────────────────────────┘
+                          │
+              ┌───────────┴───────────┐
+              │                       │
+              ▼                       ▼
+    ┌─────────────────┐     ┌─────────────────┐
+    │  Fetch DNSKEYs  │     │  Fetch Zone     │
+    │  if DO=1        │     │  Records        │
+    └────────┬────────┘     └────────┬────────┘
+             │                       │
+             └───────────┬───────────┘
+                         │
+                         ▼
+              ┌─────────────────────┐
+              │  Validate RRSets   │
+              │  (signature check) │
+              └────────┬────────────┘
+                       │
+              ┌────────┴────────┐
+              │                 │
+              ▼                 ▼
+         Valid            Invalid
+              │                 │
+              │         ┌───────┴───────┐
+              │         │               │
+              │         ▼               ▼
+              │      Mode=strict    Mode=ad-bit-only
+              │      SERVFAIL+EDE   Return (AD=0)
+              │                 │
+              └────────┬─────────┘
+                       │
+                       ▼
+              ┌─────────────────┐
+              │ Set AD bit=1   │
+              │ Return Response │
+              └─────────────────┘
+```
+
+## Query Examples
+
+### Check if a zone is signed
+
+```bash
+dig DNSKEY cloudflare.com +short
+```
+
+### Validate a response
+
+```bash
+dig A www.cloudflare.com +dnssec +ad @1.1.1.1
+```
+
+### Check EDE on failure
+
+```bash
+dig A signed-zone.example.com +dnssec +bufsize=2048
+```
+
+## References
+
+- [RFC 4033](https://tools.ietf.org/rfc/rfc4033) - DNSSEC Protocol
+- [RFC 4034](https://tools.ietf.org/rfc/rfc4034) - Resource Records
+- [RFC 4035](https://tools.ietf.org/rfc/rfc4035) - Protocol Modifications
+- [RFC 6605](https://tools.ietf.org/rfc/rfc6605) - ECDSA for DNSSEC
+- [RFC 8914](https://tools.ietf.org/rfc/rfc8914) - Extended DNS Errors
+
+## Architecture Decision
+
+See [ADR 0008](./decisions/0008-dnssec-validation.md) for detailed architecture documentation.
+
+## Implementation Roadmap
+
+See [roadmap-dnssec-validation.md](./roadmap-dnssec-validation.md) for the implementation timeline.

--- a/docs/roadmap-dnssec-validation.md
+++ b/docs/roadmap-dnssec-validation.md
@@ -34,7 +34,7 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 ---
 
-### PR 2: `dnssec-validator-service`
+### PR 2: `dnssec-validator-service` ✅ COMPLETED
 **Focus**: Trust chain validation service
 
 **Files**: `internal/core/services/dnssec_validator.go` (NEW)
@@ -48,9 +48,11 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 **Rationale**: Depends on PR1 for verification functions
 
+**Status**: Merged in `d59e189`
+
 ---
 
-### PR 3: `dnssec-port-methods`
+### PR 3: `dnssec-port-methods` ✅ COMPLETED
 **Focus**: Add ports for key fetching
 
 **Files**: `internal/core/ports/` (MODIFY)
@@ -63,9 +65,11 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 **Rationale**: Provides interface for fetching keys from repository/network
 
+**Status**: Merged in `a982a42`
+
 ---
 
-### PR 4: `dnssec-server-integration`
+### PR 4: `dnssec-server-integration` ✅ COMPLETED
 **Focus**: Server integration with AD bit and EDE
 
 **Files**: `internal/dns/server/server.go` (MODIFY)
@@ -79,9 +83,11 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 **Rationale**: Hooks validation into the packet handling pipeline
 
+**Status**: Merged in `16b4065`, `97901ac`
+
 ---
 
-### PR 5: `dnssec-trust-anchors-config`
+### PR 5: `dnssec-trust-anchors-config` ✅ COMPLETED
 **Focus**: Configuration for trust anchors
 
 **Files**: Config files + `server.go`
@@ -94,9 +100,11 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 **Rationale**: Production-ready configuration management
 
+**Status**: Merged in `0b7938c`
+
 ---
 
-### PR 6: `dnssec-recursive-keys`
+### PR 6: `dnssec-recursive-keys` ✅ COMPLETED
 **Focus**: Fetch DNSKEYs during recursive resolution
 
 **Files**: `internal/dns/server/recursive.go` (MODIFY)
@@ -109,9 +117,11 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 **Rationale**: Enables validation without pre-configured keys for every zone
 
+**Status**: Merged in `8e37d2f`
+
 ---
 
-### PR 7: `dnssec-error-handling`
+### PR 7: `dnssec-error-handling` ✅ COMPLETED
 **Focus**: Comprehensive EDE codes for validation failures
 
 **Files**: `internal/dns/packet/packet.go` + EDE constants
@@ -127,9 +137,11 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 
 **Rationale**: Better debugging for DNSSEC failures
 
+**Status**: Merged in `e493445`, `d630253`
+
 ---
 
-### PR 8: `dnssec-integration-tests`
+### PR 8: `dnssec-integration-tests` ✅ COMPLETED
 **Focus**: End-to-end integration tests
 
 **Files**: New integration test files
@@ -142,6 +154,8 @@ Implement full DNSSEC validation MVP across small, reviewable PRs.
 - Test with real recursive resolution
 
 **Rationale**: Validates the full flow works in production-like scenarios
+
+**Status**: Merged in `701561c`
 
 ---
 

--- a/features.md
+++ b/features.md
@@ -27,7 +27,7 @@ Built-in orchestration for global Anycast networks using BGP.
 *   **Historical Tracking**: Maintains a record of health check results and error messages for debugging.
 
 ## 5. Advanced DNS Standards
-*   **DNSSEC**: Automated Key (KSK/ZSK) management, signing, and Double-Signature rollover.
+*   **DNSSEC**: Automated Key (KSK/ZSK) management, signing, validation, AD bit support, and RFC 8914 EDE codes. See [docs/dnssec.md](docs/dnssec.md) for details.
 *   **DoH (DNS over HTTPS)**: Privacy-focused resolution over HTTP/2 using both `GET` and `POST`.
 *   **Dynamic Updates (RFC 2136)**: Standardized dynamic record management.
 *   **IXFR (Incremental Zone Transfer)**: RFC 1995 compliant synchronization using transactional delta logging, with intelligent AXFR fallback.


### PR DESCRIPTION
## Summary

Add comprehensive DNSSEC documentation across multiple files:

- **docs/dnssec.md** (NEW) - User-facing DNSSEC documentation covering:
  - How DNSSEC works (DNSKEY, RRSIG, DS, NSEC)
  - Three validation modes
  - RFC 8914 EDE codes
  - Resolution flow diagram
  - Query examples

- **docs/decisions/0008-dnssec-validation.md** (NEW) - Architecture decision record for DNSSEC validation implementation

- **docs/roadmap-dnssec-validation.md** (UPDATE) - Mark all 8 PRs as completed

- **features.md** (UPDATE) - Link to docs/dnssec.md

- **README.md** (UPDATE) - Promote DNSSEC to top-level feature section with link to docs

## Test plan

- [x] Documentation builds correctly
- [x] Links are valid