### PR TITLE
fix(server): replace N+1 zone lookup with single-query longest-match

### DIFF
--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -156,6 +156,33 @@ func (r *PostgresRepository) GetZone(ctx context.Context, name string) (*domain.
 	return &z, nil
 }
 
+// GetZoneLongestMatch implements ports.DNSRepository.
+// Finds the longest-matching zone for a query name using a single query.
+// This replaces the N+1 label-traversal loop with one efficient query.
+func (r *PostgresRepository) GetZoneLongestMatch(ctx context.Context, qName string) (*domain.Zone, error) {
+	query := `SELECT id, tenant_id, name, vpc_id, description, role, master_server, created_at, updated_at
+		 FROM dns_zones
+		 WHERE $1 LIKE name || '%'
+		 ORDER BY LENGTH(name) DESC
+		 LIMIT 1`
+	var z domain.Zone
+	var role, masterServer sql.NullString
+	errRow := r.db.QueryRowContext(ctx, query, qName).Scan(&z.ID, &z.TenantID, &z.Name, &z.VPCID, &z.Description, &role, &masterServer, &z.CreatedAt, &z.UpdatedAt)
+	if errors.Is(errRow, sql.ErrNoRows) {
+		return nil, nil
+	}
+	if errRow != nil {
+		return nil, errRow
+	}
+	if role.Valid {
+		z.Role = role.String
+	}
+	if masterServer.Valid {
+		z.MasterServer = masterServer.String
+	}
+	return &z, nil
+}
+
 // GetDNSKEYs implements ports.DNSRepository.
 func (r *PostgresRepository) GetDNSKEYs(ctx context.Context, zoneName string) ([]domain.Record, error) {
 	// First get the zone to find zone ID

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -162,7 +162,7 @@ func (r *PostgresRepository) GetZone(ctx context.Context, name string) (*domain.
 func (r *PostgresRepository) GetZoneLongestMatch(ctx context.Context, qName string) (*domain.Zone, error) {
 	query := `SELECT id, tenant_id, name, vpc_id, description, role, master_server, created_at, updated_at
 		 FROM dns_zones
-		 WHERE $1 LIKE name || '%'
+		 WHERE LOWER($1) LIKE LOWER(name) || '%'
 		 ORDER BY LENGTH(name) DESC
 		 LIMIT 1`
 	var z domain.Zone

--- a/internal/adapters/repository/postgres_unit_test.go
+++ b/internal/adapters/repository/postgres_unit_test.go
@@ -58,6 +58,58 @@ func TestPostgresRepository_Unit(t *testing.T) {
 		}
 	})
 
+	// 2b. Test GetZoneLongestMatch
+	t.Run("GetZoneLongestMatch", func(t *testing.T) {
+		// Test exact match
+		rows := sqlmock.NewRows([]string{"id", "tenant_id", "name", "vpc_id", "description", "role", "master_server", "created_at", "updated_at"}).
+			AddRow("z1", "t1", "example.com.", "", "", "master", "", time.Now(), time.Now())
+
+		mock.ExpectQuery(`SELECT .* FROM dns_zones WHERE LOWER\(\$1\) LIKE LOWER\(name\)`).
+			WithArgs("example.com.").
+			WillReturnRows(rows)
+
+		zone, err := repo.GetZoneLongestMatch(ctx, "example.com.")
+		if err != nil {
+			t.Errorf("GetZoneLongestMatch failed: %v", err)
+		}
+		if zone == nil || zone.ID != "z1" {
+			t.Errorf("Unexpected zone: %+v", zone)
+		}
+	})
+
+	// 2c. Test GetZoneLongestMatch subdomain
+	t.Run("GetZoneLongestMatch_Subdomain", func(t *testing.T) {
+		rows := sqlmock.NewRows([]string{"id", "tenant_id", "name", "vpc_id", "description", "role", "master_server", "created_at", "updated_at"}).
+			AddRow("z1", "t1", "example.com.", "", "", "master", "", time.Now(), time.Now())
+
+		mock.ExpectQuery(`SELECT .* FROM dns_zones WHERE LOWER\(\$1\) LIKE LOWER\(name\)`).
+			WithArgs("www.example.com.").
+			WillReturnRows(rows)
+
+		zone, err := repo.GetZoneLongestMatch(ctx, "www.example.com.")
+		if err != nil {
+			t.Errorf("GetZoneLongestMatch failed: %v", err)
+		}
+		if zone == nil || zone.Name != "example.com." {
+			t.Errorf("Unexpected zone: %+v", zone)
+		}
+	})
+
+	// 2d. Test GetZoneLongestMatch no match
+	t.Run("GetZoneLongestMatch_NoMatch", func(t *testing.T) {
+		mock.ExpectQuery(`SELECT .* FROM dns_zones WHERE LOWER\(\$1\) LIKE LOWER\(name\)`).
+			WithArgs("unknown.domain.").
+			WillReturnError(sql.ErrNoRows)
+
+		zone, err := repo.GetZoneLongestMatch(ctx, "unknown.domain.")
+		if err != nil {
+			t.Errorf("GetZoneLongestMatch should not error on no match: %v", err)
+		}
+		if zone != nil {
+			t.Errorf("Expected nil zone for unknown domain, got: %+v", zone)
+		}
+	})
+
 	// 3. Test CreateZone
 	t.Run("CreateZone", func(t *testing.T) {
 		zone := &domain.Zone{ID: "z2", Name: "new.test.", TenantID: "t1", Role: "master", MasterServer: ""}

--- a/internal/adapters/repository/schema.sql
+++ b/internal/adapters/repository/schema.sql
@@ -87,6 +87,9 @@ CREATE TABLE IF NOT EXISTS dnssec_keys (
 CREATE INDEX idx_dns_records_name ON dns_records(name);
 CREATE INDEX idx_dns_records_network ON dns_records USING gist (network inet_ops);
 
+-- Index for case-insensitive zone lookup (used by GetZoneLongestMatch)
+CREATE INDEX idx_dns_zones_name_lower ON dns_zones (LOWER(name));
+
 CREATE TABLE IF NOT EXISTS api_keys (
     id UUID PRIMARY KEY,
     tenant_id TEXT NOT NULL,

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -21,6 +21,7 @@ type DNSRepository interface {
 	GetRecords(ctx context.Context, name string, qType domain.RecordType, clientIP string) ([]domain.Record, error)
 	GetIPsForName(ctx context.Context, name string, clientIP string) ([]string, error)
 	GetZone(ctx context.Context, name string) (*domain.Zone, error)
+	GetZoneLongestMatch(ctx context.Context, qName string) (*domain.Zone, error)
 	GetRecord(ctx context.Context, id string, zoneID string, tenantID string) (*domain.Record, error)
 	ListRecordsForZone(ctx context.Context, zoneID string, tenantID string) ([]domain.Record, error)
 	ListRecordsForZoneStreaming(ctx context.Context, zoneID string, tenantID string) (RecordIterator, error)

--- a/internal/core/services/audit_test.go
+++ b/internal/core/services/audit_test.go
@@ -26,6 +26,10 @@ func (m *auditMockRepo) GetZone(ctx context.Context, name string) (*domain.Zone,
 	return m.mockRepo.GetZone(ctx, name)
 }
 
+func (m *auditMockRepo) GetZoneLongestMatch(ctx context.Context, qName string) (*domain.Zone, error) {
+	return m.mockRepo.GetZoneLongestMatch(ctx, qName)
+}
+
 func (m *auditMockRepo) ListRecordsForZone(ctx context.Context, zoneID string, tenantID string) ([]domain.Record, error) {
 	return m.mockRepo.ListRecordsForZone(ctx, zoneID, tenantID)
 }

--- a/internal/core/services/dns_service_test.go
+++ b/internal/core/services/dns_service_test.go
@@ -55,6 +55,18 @@ func (m *mockRepo) GetZone(_ context.Context, name string) (*domain.Zone, error)
 	return nil, nil
 }
 
+func (m *mockRepo) GetZoneLongestMatch(_ context.Context, qName string) (*domain.Zone, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	for _, z := range m.zones {
+		if strings.HasSuffix(qName, z.Name) || qName == z.Name {
+			return &z, nil
+		}
+	}
+	return nil, nil
+}
+
 func (m *mockRepo) GetRecord(_ context.Context, id string, zoneID string, tenantID string) (*domain.Record, error) {
 	if m.err != nil {
 		return nil, m.err

--- a/internal/core/services/dnssec_service_test.go
+++ b/internal/core/services/dnssec_service_test.go
@@ -24,6 +24,7 @@ func (m *mockDNSSECRepo) GetIPsForName(_ context.Context, _ string, _ string) ([
 	return nil, nil
 }
 func (m *mockDNSSECRepo) GetZone(_ context.Context, _ string) (*domain.Zone, error) { return nil, nil }
+func (m *mockDNSSECRepo) GetZoneLongestMatch(_ context.Context, _ string) (*domain.Zone, error) { return nil, nil }
 func (m *mockDNSSECRepo) GetRecord(_ context.Context, _ string, _ string, _ string) (*domain.Record, error) {
 	return nil, nil
 }

--- a/internal/dns/server/chaos_test.go
+++ b/internal/dns/server/chaos_test.go
@@ -23,6 +23,7 @@ func TestChaos_SimulateDBLatency(t *testing.T) {
 	srv.SimulateDBLatency = baseLatency
 
 	mockRepo.On("GetZone", mock.Anything).Return(&domain.Zone{ID: "zone1", Name: "example.com."}, nil)
+	mockRepo.On("GetZoneLongestMatch", mock.Anything, mock.Anything).Return(&domain.Zone{ID: "zone1", Name: "example.com."}, nil)
 	mockRepo.On("GetRecords", mock.Anything, mock.Anything, mock.Anything).Return([]domain.Record{
 		{Name: "example.com.", Type: domain.TypeA, Content: "1.2.3.4", TTL: 300},
 	}, nil)
@@ -59,6 +60,7 @@ func TestChaos_DBError_Query(t *testing.T) {
 
 	// Simulate database connection failure during zone and records fetch
 	mockRepo.On("GetZone", mock.Anything).Return((*domain.Zone)(nil), errors.New("simulated db connection lost"))
+	mockRepo.On("GetZoneLongestMatch", mock.Anything, mock.Anything).Return((*domain.Zone)(nil), errors.New("simulated db connection lost"))
 	mockRepo.On("GetRecords", mock.Anything, mock.Anything, mock.Anything).Return(([]domain.Record)(nil), errors.New("simulated db connection lost"))
 
 	req := packet.NewDNSPacket()
@@ -98,6 +100,7 @@ func TestChaos_DBError_Update(t *testing.T) {
 
 	// Simulate zone exists, but prerequisite check fails because GetRecords throws a DB error
 	mockRepo.On("GetZone", mock.Anything).Return(&domain.Zone{ID: "zone1", Name: "update.test."}, nil)
+	mockRepo.On("GetZoneLongestMatch", mock.Anything, mock.Anything).Return(&domain.Zone{ID: "zone1", Name: "update.test."}, nil)
 	mockRepo.On("GetRecords", mock.Anything, mock.Anything, mock.Anything).Return(([]domain.Record)(nil), errors.New("db offline"))
 
 	req := packet.NewDNSPacket()

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -896,20 +896,8 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	}
 
 	// 1. Find the zone for this query to include Authority/Additional records
-	zoneName := q.Name
-	var zone *domain.Zone
-	for {
-		z, _ := s.Repo.GetZone(ctx, zoneName)
-		if z != nil {
-			zone = z
-			break
-		}
-		idx := strings.Index(zoneName, ".")
-		if idx == -1 || idx == len(zoneName)-1 {
-			break
-		}
-		zoneName = zoneName[idx+1:]
-	}
+	// Use single-query longest-match instead of N+1 label traversal
+	zone, _ := s.Repo.GetZoneLongestMatch(ctx, q.Name)
 
 	// 2. Resolve Main Records
 	dbStart := time.Now()

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -133,6 +133,26 @@ func (m *mockServerRepo) GetZone(_ context.Context, name string) (*domain.Zone, 
 	return nil, nil
 }
 
+func (m *mockServerRepo) GetZoneLongestMatch(_ context.Context, qName string) (*domain.Zone, error) {
+	if m.failGetZone {
+		return nil, errors.New("get zone failed")
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	// Find longest matching zone
+	qNameClean := strings.TrimSuffix(strings.ToLower(qName), ".")
+	var bestMatch *domain.Zone
+	bestLen := 0
+	for _, z := range m.zones {
+		zName := strings.TrimSuffix(strings.ToLower(z.Name), ".")
+		if len(zName) > bestLen && strings.HasSuffix(qNameClean, "."+zName) {
+			bestMatch = &z
+			bestLen = len(zName)
+		}
+	}
+	return bestMatch, nil
+}
+
 func (m *mockServerRepo) GetRecord(ctx context.Context, id string, zoneID string, tenantID string) (*domain.Record, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/testutil/mock_repo.go
+++ b/internal/testutil/mock_repo.go
@@ -36,6 +36,15 @@ func (m *MockRepo) GetZone(_ context.Context, name string) (*domain.Zone, error)
 	return args.Get(0).(*domain.Zone), args.Error(1)
 }
 
+// GetZoneLongestMatch implements ports.DNSRepository for testing.
+func (m *MockRepo) GetZoneLongestMatch(_ context.Context, qName string) (*domain.Zone, error) {
+	args := m.Called(qName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Zone), args.Error(1)
+}
+
 // GetRecord implements ports.DNSRepository for testing.
 func (m *MockRepo) GetRecord(_ context.Context, id string, zoneID string, tenantID string) (*domain.Record, error) {
 	args := m.Called(id, zoneID, tenantID)


### PR DESCRIPTION
## Summary
- Replace N+1 zone lookup loop with single-query `GetZoneLongestMatch` using SQL LIKE pattern matching
- Reduces zone lookup from O(N) DB calls to O(1) per DNS query
- Reduces blast radius: for deep subdomains like `foo.bar.baz.example.com`, was doing 4+ DB calls per query

## Test plan
- [x] All short tests pass
- [ ] Full CI passes