### PR TITLE
fix: add SOA serial overflow check and nil cache guard

### DIFF
--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -861,9 +861,9 @@ func (r *PostgresRepository) ApplyZoneUpdate(ctx context.Context, zoneID string,
 		}
 	}
 	newSerial := currentSerial + 1
-	if currentSerial >= 4294967295 {
+	// Detect uint32 wraparound (Go doesn't panic on overflow, it wraps silently)
+	if newSerial == 0 && currentSerial != 0 {
 		log.Printf("SOA serial overflow, resetting to 0 for zone %s", zoneID)
-		newSerial = 0
 	}
 
 	for _, op := range operations {

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -861,6 +861,10 @@ func (r *PostgresRepository) ApplyZoneUpdate(ctx context.Context, zoneID string,
 		}
 	}
 	newSerial := currentSerial + 1
+	if currentSerial >= 4294967295 {
+		log.Printf("SOA serial overflow, resetting to 0 for zone %s", zoneID)
+		newSerial = 0
+	}
 
 	for _, op := range operations {
 		switch op.Action {

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -244,7 +244,9 @@ func (s *Server) startInvalidationListener(ctx context.Context) {
 			if len(parts) == 2 {
 				qType := packet.RecordTypeToQueryType(domain.RecordType(parts[1]))
 				l1Key := fmt.Sprintf("%s:%d", strings.ToLower(parts[0]), qType)
-				s.Cache.Invalidate(l1Key)
+				if s.Cache != nil {
+					s.Cache.Invalidate(l1Key)
+				}
 			} else {
 				s.Logger.Warn("received malformed cache invalidation payload", "payload", msg.Payload)
 			}


### PR DESCRIPTION
## Summary

Two low-risk defensive fixes:

1. **SOA serial overflow check** (`postgres.go:863`)
   - Add overflow check at 4294967295 (RFC 1982 32-bit limit)
   - Log warning and reset to 0
   - Prevents silent wraparound that would desync slaves

2. **Nil cache guard** (`server.go:247`)
   - Add nil check before `Cache.Invalidate`
   - Prevents panic when cache is disabled (Redis-only mode)

## Test plan
- [x] go test -short ./internal/adapters/repository/...
- [x] go test -short ./internal/dns/server/...
- [x] go test -short ./...