### PR TITLE
fix(server): add total timeout enforcement to recursive resolver fallback loop

### DIFF
--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -55,7 +55,10 @@ func (r *recursiveResolver) getShuffledRoots() []string {
 
 func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.DNSPacket, error) {
 	// Total timeout to prevent indefinite blocking on failing root servers
-	const recursiveTimeout = 30 * time.Second
+	const (
+		recursiveTimeout       = 30 * time.Second
+		errRecursiveTimeout     = "recursive resolution timeout"
+	)
 	resolveStart := time.Now()
 
 	// Start with a random root server for load balancing and resilience.
@@ -74,7 +77,7 @@ func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.
 		// Check total resolution timeout
 		if time.Since(resolveStart) >= recursiveTimeout {
 			s.Logger.Warn("recursive resolution timed out after 30s", "name", name)
-			return nil, errors.New("recursive resolution timeout")
+			return nil, errors.New(errRecursiveTimeout)
 		}
 		rootNS := roots[i]
 		ns := rootNS
@@ -159,8 +162,18 @@ func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.
 	}
 
 	// 2. Fallback Strategy: Use reliable upstream resolvers if iterative resolution failed
+	// Check total resolution timeout before attempting fallbacks
+	if time.Since(resolveStart) >= recursiveTimeout {
+		s.Logger.Warn("recursive resolution timed out before fallback", "name", name)
+		return nil, errors.New(errRecursiveTimeout)
+	}
 	s.Logger.Info("iterative resolution failed or inconclusive, trying fallbacks", "name", name)
 	for _, fallback := range resolver.fallbacks {
+		// Check total resolution timeout before each fallback query
+		if time.Since(resolveStart) >= recursiveTimeout {
+			s.Logger.Warn("recursive resolution timed out during fallback", "name", name)
+			return nil, errors.New(errRecursiveTimeout)
+		}
 		serverAddr := net.JoinHostPort(fallback, "53")
 		// Use sendQueryInternal with RecursionDesired=true for fallbacks
 		resp, err := s.sendQueryInternal(serverAddr, name, qType, true)

--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -19,6 +19,10 @@ type recursiveResolver struct {
 	fallbacks []string
 }
 
+// recursiveTimeout is the maximum time allowed for recursive resolution.
+// Defaults to 30s but can be overridden in tests.
+var recursiveTimeout = 30 * time.Second
+
 func newRecursiveResolver() *recursiveResolver {
 	return &recursiveResolver{
 		rootHints: []string{
@@ -55,10 +59,7 @@ func (r *recursiveResolver) getShuffledRoots() []string {
 
 func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.DNSPacket, error) {
 	// Total timeout to prevent indefinite blocking on failing root servers
-	const (
-		recursiveTimeout       = 30 * time.Second
-		errRecursiveTimeout     = "recursive resolution timeout"
-	)
+	const errRecursiveTimeout = "recursive resolution timeout"
 	resolveStart := time.Now()
 
 	// Start with a random root server for load balancing and resilience.
@@ -76,7 +77,7 @@ func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.
 	for i := 0; i < maxRoots; i++ {
 		// Check total resolution timeout
 		if time.Since(resolveStart) >= recursiveTimeout {
-			s.Logger.Warn("recursive resolution timed out after 30s", "name", name)
+			s.Logger.Warn("recursive resolution timed out during root iteration", "name", name)
 			return nil, errors.New(errRecursiveTimeout)
 		}
 		rootNS := roots[i]

--- a/internal/dns/server/recursive_test.go
+++ b/internal/dns/server/recursive_test.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"errors"
 	"io"
 	"net"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/poyrazK/cloudDNS/internal/dns/packet"
 )
@@ -263,5 +265,32 @@ func TestSendTCPQuery(t *testing.T) {
 
 	if len(resp.Answers) == 0 || resp.Answers[0].IP.String() != "1.2.3.4" {
 		t.Errorf("sendTCPQuery returned invalid response")
+	}
+}
+
+func TestResolveRecursiveFallbackTimeout(t *testing.T) {
+	// Save original timeout and restore after test
+	originalTimeout := recursiveTimeout
+	defer func() { recursiveTimeout = originalTimeout }()
+
+	// Set very short timeout for test
+	recursiveTimeout = 10 * time.Millisecond
+
+	s := NewServer(":0", nil, nil)
+
+	// Mock queryFn to fail on all servers (triggering fallback path)
+	// and be slow on fallbacks (triggering timeout before response)
+	s.queryFn = func(server string, name string, qtype packet.QueryType) (*packet.DNSPacket, error) {
+		// Simulate slow query - timeout should fire before we return
+		time.Sleep(100 * time.Millisecond)
+		return nil, errors.New("should not reach here - timeout should fire first")
+	}
+
+	_, err := s.resolveRecursive("timeout.test.", packet.A)
+	if err == nil {
+		t.Fatalf("Expected timeout error, got nil")
+	}
+	if err.Error() != "recursive resolution timeout" {
+		t.Errorf("Expected 'recursive resolution timeout', got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix recursive resolver fallback loop not checking total elapsed time against 30s timeout
- Add timeout check before fallback loop and inside fallback loop before each query
- Extract error string to constant to eliminate duplication
- Add unit test `TestResolveRecursiveFallbackTimeout` that verifies timeout fires correctly

## Test plan
- [x] `go test -short ./internal/dns/server/...` - All tests pass
- [x] `go build ./...` - Compiles
- [x] `go vet ./...` - No issues