### PR TITLE
refactor: remove non-streaming GetRecordsToProbe

### DIFF
--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -501,51 +501,6 @@ func (r *PostgresRepository) UpdateRecordHealth(ctx context.Context, recordID st
 	return err
 }
 
-// GetRecordsToProbe implements ports.DNSRepository.
-func (r *PostgresRepository) GetRecordsToProbe(ctx context.Context) ([]domain.Record, error) {
-	query := `SELECT id, zone_id, name, type, content, ttl, priority, weight, port, network, health_check_type, health_check_target 
-	          FROM dns_records 
-	          WHERE health_check_type IN ('HTTP', 'TCP')
-	          AND health_check_target IS NOT NULL AND health_check_target <> ''`
-	rows, err := r.db.QueryContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
-		}
-	}()
-
-	var records []domain.Record
-	for rows.Next() {
-		var rec domain.Record
-		var priority, weight, port sql.NullInt32
-		if errScan := rows.Scan(&rec.ID, &rec.ZoneID, &rec.Name, &rec.Type, &rec.Content, &rec.TTL, &priority, &weight, &port, &rec.Network, &rec.HealthCheckType, &rec.HealthCheckTarget); errScan != nil {
-			return nil, errScan
-		}
-		if priority.Valid {
-			p := int(priority.Int32)
-			rec.Priority = &p
-		}
-		if weight.Valid {
-			w := int(weight.Int32)
-			rec.Weight = &w
-		}
-		if port.Valid {
-			p := int(port.Int32)
-			rec.Port = &p
-		}
-		records = append(records, rec)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	return records, nil
-}
-
 // GetRecordsToProbeStreaming implements ports.DNSRepository.
 // It returns a RecordIterator that streams records with health checks configured,
 // ordered by id for consistent pagination across calls.

--- a/internal/adapters/repository/postgres_test.go
+++ b/internal/adapters/repository/postgres_test.go
@@ -197,7 +197,7 @@ func TestPostgresRepository_IXFR_And_Updates(t *testing.T) {
 		t.Errorf("Expected 0 records after DeleteRecordsForZone, got %d", len(recs))
 	}
 
-	// 8. Test GetRecordsToProbe
+	// 8. Test GetRecordsToProbeStreaming
 	// Create a record with health check within the zone
 	recHC := domain.Record{
 		ID: "550e8400-e29b-41d4-a716-446655440016", ZoneID: zID, Name: "hc.ixfr.test.",
@@ -207,13 +207,14 @@ func TestPostgresRepository_IXFR_And_Updates(t *testing.T) {
 	if err := repo.CreateRecord(ctx, &recHC); err != nil {
 		t.Fatalf("CreateRecord failed for recHC: %v", err)
 	}
-	probes, err := repo.GetRecordsToProbe(ctx)
+	iter, err := repo.GetRecordsToProbeStreaming(ctx)
 	if err != nil {
-		t.Fatalf("GetRecordsToProbe failed: %v", err)
+		t.Fatalf("GetRecordsToProbeStreaming failed: %v", err)
 	}
+	defer iter.Close()
 	foundHC := false
-	for _, p := range probes {
-		if p.ID == recHC.ID {
+	for iter.Next() {
+		if iter.Record().ID == recHC.ID {
 			foundHC = true
 			break
 		}

--- a/internal/adapters/repository/postgres_unit_test.go
+++ b/internal/adapters/repository/postgres_unit_test.go
@@ -323,15 +323,26 @@ func TestPostgresRepository_Unit(t *testing.T) {
 			t.Errorf("UpdateRecordHealth failed: %v", err)
 		}
 
-		// GetRecordsToProbe
-		rows := sqlmock.NewRows([]string{"id", "zone_id", "name", "type", "content", "ttl", "priority", "weight", "port", "network", "health_check_type", "health_check_target"}).
-			AddRow("r1", "z1", "www.test.", "A", "1.2.3.4", 300, nil, nil, nil, nil, "HTTP", "http://target")
-		mock.ExpectQuery(`SELECT .* FROM dns_records WHERE health_check_type IN \('HTTP', 'TCP'\) AND health_check_target IS NOT NULL AND health_check_target <> ''`).
-			WillReturnRows(rows)
+		// GetRecordsToProbeStreaming
+		rowsStreaming := sqlmock.NewRows([]string{"id", "zone_id", "name", "type", "content", "ttl", "priority", "weight", "port", "network", "health_check_type", "health_check_target", "status"}).
+			AddRow("r1", "z1", "www.test.", "A", "1.2.3.4", 300, nil, nil, nil, nil, "HTTP", "http://target", "HEALTHY")
+		mock.ExpectQuery(`SELECT .* FROM dns_records`).WillReturnRows(rowsStreaming)
 
-		recs, err := repo.GetRecordsToProbe(ctx)
-		if err != nil || len(recs) != 1 {
-			t.Errorf("GetRecordsToProbe failed: %v", err)
+		iter, err := repo.GetRecordsToProbeStreaming(ctx)
+		if err != nil {
+			t.Errorf("GetRecordsToProbeStreaming failed: %v", err)
+		}
+		if iter == nil {
+			t.Error("iterator was nil")
+		} else {
+			defer iter.Close()
+			count := 0
+			for iter.Next() {
+				count++
+			}
+			if count != 1 {
+				t.Errorf("expected 1 record, got %d", count)
+			}
 		}
 	})
 
@@ -600,16 +611,6 @@ func TestPostgresRepository_Extra_Unit(t *testing.T) {
 			_, err := repo.ApplyZoneUpdate(ctx, "z1", nil, nil)
 			if err == nil { t.Error("expected error") }
 		})
-	})
-
-	t.Run("GetRecordsToProbe_ScanError", func(t *testing.T) {
-		db, mock, _ := sqlmock.New()
-		defer db.Close()
-		repo := NewPostgresRepository(db)
-		rows := sqlmock.NewRows([]string{"id"}).AddRow(123) // Wrong columns/types
-		mock.ExpectQuery("SELECT .* FROM dns_records").WillReturnRows(rows)
-		_, err := repo.GetRecordsToProbe(ctx)
-		if err == nil { t.Error("expected error") }
 	})
 
 	t.Run("ListAPIKeys_ScanError", func(t *testing.T) {

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -61,7 +61,6 @@ type DNSRepository interface {
 
 	// Smart Engine (GSLB) Support
 	UpdateRecordHealth(ctx context.Context, recordID string, status domain.HealthStatus, errMsg string) error
-	GetRecordsToProbe(ctx context.Context) ([]domain.Record, error)
 	GetRecordsToProbeStreaming(ctx context.Context) (RecordIterator, error)
 }
 
@@ -70,7 +69,6 @@ type DNSService interface {
 	CreateZone(ctx context.Context, zone *domain.Zone) error
 	CreateRecord(ctx context.Context, record *domain.Record) error
 	Resolve(ctx context.Context, name string, qType domain.RecordType, clientIP string) ([]domain.Record, error)
-	GetRecordsToProbe(ctx context.Context) ([]domain.Record, error) // Added for Smart Engine
 	GetRecordsToProbeStreaming(ctx context.Context) (RecordIterator, error) // Added for Smart Engine
 	UpdateRecordHealth(ctx context.Context, recordID string, status domain.HealthStatus, errMsg string) error // Added for Smart Engine
 	ListZones(ctx context.Context, tenantID string) ([]domain.Zone, error)

--- a/internal/core/services/anycast_manager_test.go
+++ b/internal/core/services/anycast_manager_test.go
@@ -54,10 +54,6 @@ func (m *mockAnycastDNSService) ListAuditLogs(_ context.Context, _ string) ([]do
 	return nil, nil
 }
 
-func (m *mockAnycastDNSService) GetRecordsToProbe(_ context.Context) ([]domain.Record, error) {
-	return nil, nil
-}
-
 func (m *mockAnycastDNSService) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {
 	return &emptyRecordIterator{}, nil
 }
@@ -156,10 +152,6 @@ type mockMultiBackendService struct {
 
 func (m *mockMultiBackendService) HealthCheck(_ context.Context) map[string]error {
 	return m.status
-}
-
-func (m *mockMultiBackendService) GetRecordsToProbe(_ context.Context) ([]domain.Record, error) {
-	return nil, nil
 }
 
 func (m *mockMultiBackendService) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {

--- a/internal/core/services/audit_test.go
+++ b/internal/core/services/audit_test.go
@@ -79,10 +79,6 @@ func (m *auditMockRepo) DeleteAPIKey(ctx context.Context, tenantID string, id st
 	return m.mockRepo.DeleteAPIKey(ctx, tenantID, id)
 }
 
-func (m *auditMockRepo) GetRecordsToProbe(ctx context.Context) ([]domain.Record, error) {
-	return m.mockRepo.GetRecordsToProbe(ctx)
-}
-
 func (m *auditMockRepo) GetRecordsToProbeStreaming(ctx context.Context) (ports.RecordIterator, error) {
 	return m.mockRepo.GetRecordsToProbeStreaming(ctx)
 }

--- a/internal/core/services/dns_service.go
+++ b/internal/core/services/dns_service.go
@@ -240,11 +240,6 @@ func (s *dnsService) ListAuditLogs(ctx context.Context, tenantID string) ([]doma
 	return s.repo.GetAuditLogs(ctx, tenantID)
 }
 
-// GetRecordsToProbe fetches all records that have a health check configured.
-func (s *dnsService) GetRecordsToProbe(ctx context.Context) ([]domain.Record, error) {
-	return s.repo.GetRecordsToProbe(ctx)
-}
-
 // GetRecordsToProbeStreaming returns an iterator for records that have health checks configured.
 func (s *dnsService) GetRecordsToProbeStreaming(ctx context.Context) (ports.RecordIterator, error) {
 	return s.repo.GetRecordsToProbeStreaming(ctx)

--- a/internal/core/services/dns_service_test.go
+++ b/internal/core/services/dns_service_test.go
@@ -257,14 +257,14 @@ func (m *mockRepo) ListAPIKeys(_ context.Context, _ string) ([]domain.APIKey, er
 }
 func (m *mockRepo) DeleteAPIKey(_ context.Context, _ string, _ string) error { return m.err }
 
-func (m *mockRepo) GetRecordsToProbe(_ context.Context) ([]domain.Record, error) {
+func (m *mockRepo) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
-	return []domain.Record{{ID: "probe-1"}}, nil
-}
-
-func (m *mockRepo) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {
+	if len(m.records) == 0 {
+		// Default to probe record if no records seeded (for backward compat with tests)
+		return &testRecordIterator{records: []domain.Record{{ID: "probe-1"}}}, nil
+	}
 	return &testRecordIterator{records: m.records}, nil
 }
 
@@ -283,10 +283,18 @@ func TestDNSService_ExtraMethods(t *testing.T) {
 		t.Errorf("ListAuditLogs failed: %v", err)
 	}
 
-	// 2. Test GetRecordsToProbe
-	probes, err := svc.GetRecordsToProbe(ctx)
-	if err != nil || len(probes) != 1 {
-		t.Errorf("GetRecordsToProbe failed: %v", err)
+	// 2. Test GetRecordsToProbeStreaming
+	iter, err := svc.GetRecordsToProbeStreaming(ctx)
+	if err != nil {
+		t.Errorf("GetRecordsToProbeStreaming failed: %v", err)
+	}
+	defer iter.Close()
+	count := 0
+	for iter.Next() {
+		count++
+	}
+	if count != 1 {
+		t.Errorf("expected 1 record, got %d", count)
 	}
 
 	// 3. Test UpdateRecordHealth
@@ -307,9 +315,9 @@ func TestDNSService_ExtraMethods(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for ListAuditLogs")
 	}
-	_, err = svc.GetRecordsToProbe(ctx)
+	_, err = svc.GetRecordsToProbeStreaming(ctx)
 	if err == nil {
-		t.Error("Expected error for GetRecordsToProbe")
+		t.Error("Expected error for GetRecordsToProbeStreaming")
 	}
 	err = svc.UpdateRecordHealth(ctx, "r1", domain.HealthStatusHealthy, "")
 	if err == nil {

--- a/internal/core/services/dnssec_service_test.go
+++ b/internal/core/services/dnssec_service_test.go
@@ -74,10 +74,6 @@ func (m *mockDNSSECRepo) UpdateRecordHealth(_ context.Context, _ string, _ domai
 	return nil
 }
 
-func (m *mockDNSSECRepo) GetRecordsToProbe(_ context.Context) ([]domain.Record, error) {
-	return nil, nil
-}
-
 func (m *mockDNSSECRepo) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {
 	return nil, nil
 }

--- a/internal/testutil/mock_repo.go
+++ b/internal/testutil/mock_repo.go
@@ -240,15 +240,6 @@ func (m *MockRepo) UpdateRecordHealth(ctx context.Context, recordID string, stat
 	return args.Error(0)
 }
 
-// GetRecordsToProbe implements ports.DNSRepository for testing.
-func (m *MockRepo) GetRecordsToProbe(_ context.Context) ([]domain.Record, error) {
-	args := m.Called()
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]domain.Record), args.Error(1)
-}
-
 // GetRecordsToProbeStreaming implements ports.DNSRepository for testing.
 func (m *MockRepo) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {
 	args := m.Called()
@@ -278,15 +269,6 @@ func (m *MockDNSService) CreateRecord(_ context.Context, record *domain.Record) 
 // Resolve implements ports.DNSService for testing.
 func (m *MockDNSService) Resolve(_ context.Context, name string, qType domain.RecordType, clientIP string) ([]domain.Record, error) {
 	args := m.Called(name, qType, clientIP)
-	return args.Get(0).([]domain.Record), args.Error(1)
-}
-
-// GetRecordsToProbe implements ports.DNSService for testing.
-func (m *MockDNSService) GetRecordsToProbe(_ context.Context) ([]domain.Record, error) {
-	args := m.Called()
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
 	return args.Get(0).([]domain.Record), args.Error(1)
 }
 

--- a/internal/testutil/mock_repo_test.go
+++ b/internal/testutil/mock_repo_test.go
@@ -251,10 +251,34 @@ func TestMockRepo_Health(t *testing.T) {
 	err := m.UpdateRecordHealth(context.Background(), "r1", domain.HealthStatusHealthy, "ok")
 	if err != nil { t.Errorf("UpdateRecordHealth failed") }
 
-	m.On("GetRecordsToProbe", mock.Anything).Return([]domain.Record{{ID: "r1"}}, nil)
-	probes, err := m.GetRecordsToProbe(context.Background())
-	if err != nil || len(probes) != 1 { t.Errorf("GetRecordsToProbe failed") }
+	// Test GetRecordsToProbeStreaming - uses a simple mock iterator
+	mockedIter := &mockRecordIterator{records: []domain.Record{{ID: "r1"}}, index: 0}
+	m.On("GetRecordsToProbeStreaming", mock.Anything).Return(mockedIter, nil)
+	iter, err := m.GetRecordsToProbeStreaming(context.Background())
+	if err != nil || iter == nil { t.Errorf("GetRecordsToProbeStreaming failed") }
 }
+
+// mockRecordIterator is a simple implementation for testing
+type mockRecordIterator struct {
+	records []domain.Record
+	index   int
+}
+
+func (m *mockRecordIterator) Next() bool {
+	m.index++
+	return m.index <= len(m.records)
+}
+
+func (m *mockRecordIterator) Err() error { return nil }
+
+func (m *mockRecordIterator) Record() domain.Record {
+	if m.index > 0 && m.index <= len(m.records) {
+		return m.records[m.index-1]
+	}
+	return domain.Record{}
+}
+
+func (m *mockRecordIterator) Close() error { return nil }
 
 func TestMockRepo_DeleteRecordsForZone(t *testing.T) {
 	m := new(MockRepo)
@@ -281,9 +305,9 @@ func TestMockDNSService(t *testing.T) {
 	recs, err := m.Resolve(ctx, "test.", domain.TypeA, "1.1")
 	if err != nil || len(recs) != 1 { t.Errorf("Resolve failed") }
 
-	m.On("GetRecordsToProbe").Return([]domain.Record{{ID: "r1"}}, nil)
-	probes, err := m.GetRecordsToProbe(ctx)
-	if err != nil || len(probes) != 1 { t.Errorf("GetRecordsToProbe failed") }
+	m.On("GetRecordsToProbeStreaming").Return(&mockRecordIterator{records: []domain.Record{{ID: "r1"}}, index: 0}, nil)
+	iter, err := m.GetRecordsToProbeStreaming(ctx)
+	if err != nil || iter == nil { t.Errorf("GetRecordsToProbeStreaming failed") }
 
 	m.On("UpdateRecordHealth", "r1", domain.HealthStatusHealthy, "ok").Return(nil)
 	err = m.UpdateRecordHealth(ctx, "r1", domain.HealthStatusHealthy, "ok")


### PR DESCRIPTION
## Summary
- Remove the unsafe non-streaming `GetRecordsToProbe` method that loads all records into memory
- Only the streaming `GetRecordsToProbeStreaming` version remains - already correctly used by HealthMonitor with batch processing
- Prevents accidental OOM on large deployments (10M+ records)

## Changes
- **Core interface** (`ports.go`, `dns_service.go`): Remove method from interface and service
- **Postgres repository**: Remove implementation and update tests to use iterator pattern
- **Test mocks**: Update MockRepo and service tests to use streaming version
- **Bug report**: Mark issue as FIXED

## Test Plan
- [x] `go build ./...` - Compiles without errors
- [x] `go test -short ./...` - All tests pass
- [x] HealthMonitor still works via streaming path (verified in code review)

## Why this is safe
The non-streaming method was **unused in production** - HealthMonitor already used `GetRecordsToProbeStreaming` with proper batch processing (100 records/batch, 10 concurrent workers). The removed method was dangerous because:
1. It could cause OOM if accidentally used on large deployments
2. It provided no streaming/batching like the correct version