### PR TITLE
fix(dnssec): ValidateChain now verifies RRSIG_DS signatures

### DIFF
--- a/internal/core/services/dnssec_validator.go
+++ b/internal/core/services/dnssec_validator.go
@@ -295,32 +295,34 @@ func (v *DNSSECValidator) ValidateChain(chain []ChainLink, now uint32) error {
 
 			// Verify RRSIG_DS signatures using parent zone's DNSKEYs (chain[i+1].DNSKEYs)
 			// The DS record for zone[i] is signed by the parent zone's ZSK
-			if i+1 < len(chain) {
+			if link.DS.Type != 0 && i+1 < len(chain) {
 				parentLink := &chain[i+1]
-				if len(link.RRSIGsDS) > 0 && len(parentLink.DNSKEYs) > 0 {
-					// Find the RRSIG that covers DS (TypeCovered should be DS)
-					var rrsig *packet.DNSRecord
-					for idx := range link.RRSIGsDS {
-						if link.RRSIGsDS[idx].Type == packet.RRSIG && link.RRSIGsDS[idx].TypeCovered == uint16(packet.DS) {
-							rrsig = &link.RRSIGsDS[idx]
-							break
-						}
+				if len(parentLink.DNSKEYs) == 0 {
+					return fmt.Errorf("dnssec: chain link %d: DS present but parent zone has no DNSKEYs", i)
+				}
+				if len(link.RRSIGsDS) == 0 {
+					return fmt.Errorf("dnssec: chain link %d: DS present but no RRSIGsDS provided", i)
+				}
+				var lastErr error
+				foundValid := false
+				for idx := range link.RRSIGsDS {
+					rrsig := &link.RRSIGsDS[idx]
+					if rrsig.Type != packet.RRSIG || rrsig.TypeCovered != uint16(packet.DS) {
+						continue
 					}
-					if rrsig == nil {
-						return fmt.Errorf("dnssec: chain link %d: no RRSIG found for DS", i)
-					}
-
-					// Find matching DNSKEY in parent zone to verify the RRSIG
 					parentDNSKEY := packet.FindMatchingDNSKEY(*rrsig, parentLink.DNSKEYs)
 					if parentDNSKEY == nil {
-						return fmt.Errorf("dnssec: chain link %d: no matching DNSKEY in parent zone for RRSIG_DS", i)
+						continue
 					}
-
-					// Verify the RRSIG_DS signature
 					valid, err := packet.VerifyRRSet([]packet.DNSRecord{link.DS}, *rrsig, *parentDNSKEY, now)
-					if err != nil || !valid {
-						return fmt.Errorf("dnssec: chain link %d: RRSIG_DS signature verification failed: %w", i, err)
+					if err == nil && valid {
+						foundValid = true
+						break
 					}
+					lastErr = err
+				}
+				if !foundValid {
+					return fmt.Errorf("dnssec: chain link %d: no valid RRSIG_DS found: %w", i, lastErr)
 				}
 			}
 		}

--- a/internal/core/services/dnssec_validator.go
+++ b/internal/core/services/dnssec_validator.go
@@ -252,15 +252,16 @@ func (v *DNSSECValidator) ValidateDNSKEYChain(dnskeys []packet.DNSRecord, ds, _ 
 
 // ChainLink represents a single step in the DNSSEC validation chain.
 type ChainLink struct {
-	Zone      string           // Zone name (e.g., "example.com.")
+	Zone      string             // Zone name (e.g., "example.com.")
 	DNSKEYs   []packet.DNSRecord // DNSKEYs for this zone
-	DS        packet.DNSRecord  // DS record in parent (empty for trust anchor zone)
+	DS        packet.DNSRecord   // DS record in parent (empty for trust anchor zone)
+	RRSIGsDS  []packet.DNSRecord // RRSIG records signing the DS RRset
 }
 
 // ValidateChain validates the full DNSSEC trust chain from a leaf zone to a trust anchor.
 // It verifies that each zone's DNSKEY is valid according to its DS record,
 // and that DS records are properly signed up the chain to the trust anchor.
-func (v *DNSSECValidator) ValidateChain(chain []ChainLink, _ uint32) error {
+func (v *DNSSECValidator) ValidateChain(chain []ChainLink, now uint32) error {
 	if len(chain) == 0 {
 		return fmt.Errorf("dnssec: empty chain")
 	}
@@ -290,6 +291,37 @@ func (v *DNSSECValidator) ValidateChain(chain []ChainLink, _ uint32) error {
 			// Validate DNSKEY format
 			if valid, err := packet.ValidateDNSKEYFormat(*matchedDNSKEY); !valid || err != nil {
 				return fmt.Errorf("dnssec: chain link %d: invalid dnskey format: %w", i, err)
+			}
+
+			// Verify RRSIG_DS signatures using parent zone's DNSKEYs (chain[i+1].DNSKEYs)
+			// The DS record for zone[i] is signed by the parent zone's ZSK
+			if i+1 < len(chain) {
+				parentLink := &chain[i+1]
+				if len(link.RRSIGsDS) > 0 && len(parentLink.DNSKEYs) > 0 {
+					// Find the RRSIG that covers DS (TypeCovered should be DS)
+					var rrsig *packet.DNSRecord
+					for idx := range link.RRSIGsDS {
+						if link.RRSIGsDS[idx].Type == packet.RRSIG && link.RRSIGsDS[idx].TypeCovered == uint16(packet.DS) {
+							rrsig = &link.RRSIGsDS[idx]
+							break
+						}
+					}
+					if rrsig == nil {
+						return fmt.Errorf("dnssec: chain link %d: no RRSIG found for DS", i)
+					}
+
+					// Find matching DNSKEY in parent zone to verify the RRSIG
+					parentDNSKEY := packet.FindMatchingDNSKEY(*rrsig, parentLink.DNSKEYs)
+					if parentDNSKEY == nil {
+						return fmt.Errorf("dnssec: chain link %d: no matching DNSKEY in parent zone for RRSIG_DS", i)
+					}
+
+					// Verify the RRSIG_DS signature
+					valid, err := packet.VerifyRRSet([]packet.DNSRecord{link.DS}, *rrsig, *parentDNSKEY, now)
+					if err != nil || !valid {
+						return fmt.Errorf("dnssec: chain link %d: RRSIG_DS signature verification failed: %w", i, err)
+					}
+				}
 			}
 		}
 

--- a/internal/core/services/dnssec_validator_test.go
+++ b/internal/core/services/dnssec_validator_test.go
@@ -533,24 +533,32 @@ func TestValidateChain_TwoZoneChain(t *testing.T) {
 	validator := NewDNSSECValidator(nil)
 
 	// Create keys for two zones
-	comDNSKEY, _ := makeTestDNSKEY(t)
+	comDNSKEY, comPrivKey := makeTestDNSKEY(t)
 	comDNSKEY.Name = "com."
 
 	exampleDNSKEY, _ := makeTestDNSKEY(t)
 	exampleDNSKEY.Name = "example.com."
 
-	// Compute DS for example.com using com's DNSKEY
+	// Compute DS from example.com's DNSKEY (DS is derived from child zone)
 	ds, err := exampleDNSKEY.ComputeDS(2) // SHA-256
 	if err != nil {
 		t.Fatalf("Failed to compute DS: %v", err)
 	}
 
+	// Sign DS with com's key (parent zone signs child's DS)
+	now := uint32(1000)
+	rrsig, err := packet.SignRRSet([]packet.DNSRecord{ds}, comPrivKey, packet.AlgorithmECDSAP256, "com.", comDNSKEY.ComputeKeyTag(), now-60, now+3600)
+	if err != nil {
+		t.Fatalf("Failed to sign DS: %v", err)
+	}
+
 	// Chain: example.com -> com
 	chain := []ChainLink{
 		{
-			Zone:    "example.com.",
-			DNSKEYs: []packet.DNSRecord{exampleDNSKEY},
-			DS:      ds,
+			Zone:     "example.com.",
+			DNSKEYs:  []packet.DNSRecord{exampleDNSKEY},
+			DS:       ds,
+			RRSIGsDS: []packet.DNSRecord{rrsig},
 		},
 		{
 			Zone:    "com.",
@@ -559,7 +567,7 @@ func TestValidateChain_TwoZoneChain(t *testing.T) {
 		},
 	}
 
-	err = validator.ValidateChain(chain, uint32(1000))
+	err = validator.ValidateChain(chain, now)
 	if err != nil {
 		t.Errorf("Expected valid two-zone chain, got error: %v", err)
 	}
@@ -567,7 +575,7 @@ func TestValidateChain_TwoZoneChain(t *testing.T) {
 
 func TestValidateChain_WithTrustAnchor(t *testing.T) {
 	// Create root anchor
-	rootDNSKEY, _ := makeTestDNSKEY(t)
+	rootDNSKEY, rootPrivKey := makeTestDNSKEY(t)
 	rootDNSKEY.Name = "."
 
 	trustAnchors := map[string]packet.DNSRecord{
@@ -576,33 +584,42 @@ func TestValidateChain_WithTrustAnchor(t *testing.T) {
 	validator := NewDNSSECValidator(trustAnchors)
 
 	// Create DNSKEYs for com and example
-	comDNSKEY, _ := makeTestDNSKEY(t)
+	comDNSKEY, comPrivKey := makeTestDNSKEY(t)
 	comDNSKEY.Name = "com."
 
 	exampleDNSKEY, _ := makeTestDNSKEY(t)
 	exampleDNSKEY.Name = "example.com."
 
-	// example.com DS signed by com's key
+	// Compute DS records from child zone's DNSKEY
 	exampleDS, _ := exampleDNSKEY.ComputeDS(2)
-
-	// com DS signed by root's key
 	comDS, _ := comDNSKEY.ComputeDS(2)
+
+	// Sign DS records with parent zone's key
+	now := uint32(1000)
+
+	// example.com's DS signed by com's key
+	exampleRRSIG, _ := packet.SignRRSet([]packet.DNSRecord{exampleDS}, comPrivKey, packet.AlgorithmECDSAP256, "com.", comDNSKEY.ComputeKeyTag(), now-60, now+3600)
+
+	// com's DS signed by root's key
+	comRRSIG, _ := packet.SignRRSet([]packet.DNSRecord{comDS}, rootPrivKey, packet.AlgorithmECDSAP256, ".", rootDNSKEY.ComputeKeyTag(), now-60, now+3600)
 
 	// Chain: example.com -> com -> root (trust anchor)
 	chain := []ChainLink{
 		{
-			Zone:    "example.com.",
-			DNSKEYs: []packet.DNSRecord{exampleDNSKEY},
-			DS:      exampleDS,
+			Zone:     "example.com.",
+			DNSKEYs:  []packet.DNSRecord{exampleDNSKEY},
+			DS:       exampleDS,
+			RRSIGsDS: []packet.DNSRecord{exampleRRSIG},
 		},
 		{
-			Zone:    "com.",
-			DNSKEYs: []packet.DNSRecord{comDNSKEY},
-			DS:      comDS,
+			Zone:     "com.",
+			DNSKEYs:  []packet.DNSRecord{comDNSKEY},
+			DS:       comDS,
+			RRSIGsDS: []packet.DNSRecord{comRRSIG},
 		},
 	}
 
-	err := validator.ValidateChain(chain, uint32(1000))
+	err := validator.ValidateChain(chain, now)
 	if err != nil {
 		t.Errorf("Expected valid chain with trust anchor, got error: %v", err)
 	}
@@ -685,7 +702,7 @@ func TestValidateChain_InvalidRRSIGDSSignature(t *testing.T) {
 	}
 }
 
-func TestValidateChain_MissingRRSIGDS(t *testing.T) {
+func TestValidateChain_InvalidRRSIGDSSignature_GarbageSig(t *testing.T) {
 	validator := NewDNSSECValidator(nil)
 
 	// Create key for com zone
@@ -696,7 +713,7 @@ func TestValidateChain_MissingRRSIGDS(t *testing.T) {
 	exampleDNSKEY, _ := makeTestDNSKEY(t)
 	exampleDNSKEY.Name = "example.com."
 
-	// Compute DS for example.com using com's DNSKEY
+	// Compute DS from example.com's DNSKEY (DS is derived from child zone)
 	ds, err := exampleDNSKEY.ComputeDS(2) // SHA-256
 	if err != nil {
 		t.Fatalf("Failed to compute DS: %v", err)

--- a/internal/core/services/dnssec_validator_test.go
+++ b/internal/core/services/dnssec_validator_test.go
@@ -632,6 +632,112 @@ func TestValidateChain_DNSKEYMismatch(t *testing.T) {
 	}
 }
 
+func TestValidateChain_InvalidRRSIGDSSignature(t *testing.T) {
+	validator := NewDNSSECValidator(nil)
+
+	// Create key for com zone
+	comDNSKEY, comPrivKey := makeTestDNSKEY(t)
+	comDNSKEY.Name = "com."
+
+	// Create different key for example.com
+	exampleDNSKEY, _ := makeTestDNSKEY(t)
+	exampleDNSKEY.Name = "example.com."
+
+	// Compute DS for example.com using com's DNSKEY
+	ds, err := exampleDNSKEY.ComputeDS(2) // SHA-256
+	if err != nil {
+		t.Fatalf("Failed to compute DS: %v", err)
+	}
+
+	// Sign the DS with com's key (correct)
+	now := uint32(1000)
+	rrsig, err := packet.SignRRSet([]packet.DNSRecord{ds}, comPrivKey, packet.AlgorithmECDSAP256, "com.", comDNSKEY.ComputeKeyTag(), now-60, now+3600)
+	if err != nil {
+		t.Fatalf("Failed to sign DS: %v", err)
+	}
+
+	// Chain: example.com -> com
+	chain := []ChainLink{
+		{
+			Zone:     "example.com.",
+			DNSKEYs:  []packet.DNSRecord{exampleDNSKEY},
+			DS:       ds,
+			RRSIGsDS: []packet.DNSRecord{rrsig},
+		},
+		{
+			Zone:    "com.",
+			DNSKEYs: []packet.DNSRecord{comDNSKEY},
+			DS:      packet.DNSRecord{},
+		},
+	}
+
+	// Valid signature should pass
+	err = validator.ValidateChain(chain, now)
+	if err != nil {
+		t.Errorf("Expected valid chain with correct RRSIG_DS, got error: %v", err)
+	}
+
+	// Corrupt the signature to make it invalid
+	chain[0].RRSIGsDS[0].Signature[0] ^= 0xFF
+	err = validator.ValidateChain(chain, now)
+	if err == nil {
+		t.Error("Expected error when RRSIG_DS signature is invalid")
+	}
+}
+
+func TestValidateChain_MissingRRSIGDS(t *testing.T) {
+	validator := NewDNSSECValidator(nil)
+
+	// Create key for com zone
+	comDNSKEY, _ := makeTestDNSKEY(t)
+	comDNSKEY.Name = "com."
+
+	// Create key for example.com
+	exampleDNSKEY, _ := makeTestDNSKEY(t)
+	exampleDNSKEY.Name = "example.com."
+
+	// Compute DS for example.com using com's DNSKEY
+	ds, err := exampleDNSKEY.ComputeDS(2) // SHA-256
+	if err != nil {
+		t.Fatalf("Failed to compute DS: %v", err)
+	}
+
+	// Create a valid RRSIG but with garbage signature (won't match)
+	garbageSig := make([]byte, 64)
+	rrsig := packet.DNSRecord{
+		Type:         packet.RRSIG,
+		TypeCovered:  uint16(packet.DS),
+		Algorithm:    comDNSKEY.Algorithm,
+		KeyTag:       comDNSKEY.ComputeKeyTag(),
+		SignerName:   "com.",
+		Expiration:   uint32(2000),
+		Inception:    uint32(500),
+		OrigTTL:      300,
+		Labels:       2,
+		Signature:    garbageSig, // Invalid signature
+	}
+
+	// Chain: example.com -> com (with DS and RRSIGsDS with invalid signature)
+	chain := []ChainLink{
+		{
+			Zone:     "example.com.",
+			DNSKEYs:  []packet.DNSRecord{exampleDNSKEY},
+			DS:       ds,
+			RRSIGsDS: []packet.DNSRecord{rrsig},
+		},
+		{
+			Zone:    "com.",
+			DNSKEYs: []packet.DNSRecord{comDNSKEY},
+			DS:      packet.DNSRecord{},
+		},
+	}
+
+	err = validator.ValidateChain(chain, uint32(1000))
+	if err == nil {
+		t.Error("Expected error when RRSIG_DS signature is invalid")
+	}
+}
+
 func TestValidateChain_TrustAnchorMismatch(t *testing.T) {
 	// Create root anchor
 	rootDNSKEY, _ := makeTestDNSKEY(t)

--- a/internal/dns/server/dnssec_integration_test.go
+++ b/internal/dns/server/dnssec_integration_test.go
@@ -274,10 +274,10 @@ func encodeECDSAPublicKey(pub *ecdsa.PublicKey) []byte {
 // from root trust anchor through TLD to leaf zone.
 func TestDNSSEC_ValidateChain_ThreeZoneChain(t *testing.T) {
 	// Create root anchor
-	rootDNSKEY, _ := makeTestDNSKEYWithName(t, ".")
+	rootDNSKEY, rootPrivKey := makeTestDNSKEYWithName(t, ".")
 
 	// Create keys for com and example
-	comDNSKEY, _ := makeTestDNSKEYWithName(t, "com.")
+	comDNSKEY, comPrivKey := makeTestDNSKEYWithName(t, "com.")
 	exampleDNSKEY, _ := makeTestDNSKEYWithName(t, "example.com.")
 
 	trustAnchors := map[string]packet.DNSRecord{
@@ -289,21 +289,32 @@ func TestDNSSEC_ValidateChain_ThreeZoneChain(t *testing.T) {
 	exampleDS, _ := exampleDNSKEY.ComputeDS(2) // SHA-256
 	comDS, _ := comDNSKEY.ComputeDS(2)
 
+	// Sign DS records with parent zone's key
+	now := uint32(1000)
+
+	// example.com's DS signed by com's key
+	exampleRRSIG, _ := packet.SignRRSet([]packet.DNSRecord{exampleDS}, comPrivKey, packet.AlgorithmECDSAP256, "com.", comDNSKEY.ComputeKeyTag(), now-60, now+3600)
+
+	// com's DS signed by root's key
+	comRRSIG, _ := packet.SignRRSet([]packet.DNSRecord{comDS}, rootPrivKey, packet.AlgorithmECDSAP256, ".", rootDNSKEY.ComputeKeyTag(), now-60, now+3600)
+
 	// Build chain: example.com -> com -> root (trust anchor)
 	chain := []services.ChainLink{
 		{
-			Zone:    "example.com.",
-			DNSKEYs: []packet.DNSRecord{exampleDNSKEY},
-			DS:      exampleDS,
+			Zone:     "example.com.",
+			DNSKEYs:  []packet.DNSRecord{exampleDNSKEY},
+			DS:       exampleDS,
+			RRSIGsDS: []packet.DNSRecord{exampleRRSIG},
 		},
 		{
-			Zone:    "com.",
-			DNSKEYs: []packet.DNSRecord{comDNSKEY},
-			DS:      comDS,
+			Zone:     "com.",
+			DNSKEYs:  []packet.DNSRecord{comDNSKEY},
+			DS:       comDS,
+			RRSIGsDS: []packet.DNSRecord{comRRSIG},
 		},
 	}
 
-	err := validator.ValidateChain(chain, uint32(1000))
+	err := validator.ValidateChain(chain, now)
 	if err != nil {
 		t.Errorf("Expected valid 3-zone chain, got error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Fix issue #92: `ValidateChain` never verified RRSIG signatures over DS records
- Add `RRSIGsDS` field to `ChainLink` struct to carry RRSIG records signing the DS RRset
- Update `ValidateChain` to verify RRSIG_DS signatures using parent zone's DNSKEYs (per RFC 4034 Section 5.3.2)

## Problem
The DS record for a zone is signed by the **parent zone's** ZSK, not the child's own key. The old `ValidateChain` only checked cryptographic consistency between DNSKEY and DS (via `VerifyDNSKEYMatchesDS`) but never verified the RRSIG_DS signatures.

## Solution
For each chain link with a DS record, `ValidateChain` now:
1. Finds the RRSIG covering DS (`TypeCovered == DS`)
2. Uses parent zone's DNSKEYs (`chain[i+1].DNSKEYs`) to verify the signature
3. Calls `packet.VerifyRRSet()` to cryptographically verify the RRSIG_DS signature

## Test plan
- [x] `go test ./internal/core/services/... -run ValidateChain` - all pass
- [x] `go test ./internal/dns/server/... -run ValidateChain` - all pass
- [x] Added `TestValidateChain_InvalidRRSIGDSSignature` - verifies corrupted signature is rejected
- [x] Added `TestValidateChain_MissingRRSIGDS` - verifies invalid RRSIG_DS is rejected