### PR TITLE
fix: address security issues in API and DNS server

### DIFF
--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -3,13 +3,27 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/poyrazK/cloudDNS/internal/core/domain"
 	"github.com/poyrazK/cloudDNS/internal/core/ports"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
+
+const maxBodySize = 1 << 20 // 1MB
+
+// validateContentType checks if Content-Type is application/json.
+// Returns true if empty (backward compat) or has JSON prefix.
+func validateContentType(r *http.Request) bool {
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "" {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(strings.Split(contentType, ";")[0]), "application/json")
+}
 
 // Handler handles HTTP requests for zone and record management.
 type Handler struct {
@@ -34,6 +48,10 @@ func New(svc ports.DNSService, repo ports.DNSRepository, logger *slog.Logger) *H
 
 // RegisterRoutes registers the API routes with the provided ServeMux.
 func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	// CORS middleware
+	corsConfig := DefaultCORSConfig()
+	cors := CORSMiddleware(corsConfig)
+
 	// Public Routes
 	mux.HandleFunc("GET /health", h.HealthCheck)
 	mux.HandleFunc("GET /metrics", h.Metrics)
@@ -50,17 +68,17 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 
 	// Protected Routes (scoped by tenant_id from auth key)
 	// Read operations - rate limited
-	mux.Handle("GET /zones", auth(rateLimitRead(http.HandlerFunc(h.ListZones))))
-	mux.Handle("GET /zones/{id}/records", auth(rateLimitRead(http.HandlerFunc(h.ListRecordsForZone))))
-	mux.Handle("GET /audit-logs", auth(rateLimitRead(http.HandlerFunc(h.ListAuditLogs))))
+	mux.Handle("GET /zones", cors(auth(rateLimitRead(http.HandlerFunc(h.ListZones)))))
+	mux.Handle("GET /zones/{id}/records", cors(auth(rateLimitRead(http.HandlerFunc(h.ListRecordsForZone)))))
+	mux.Handle("GET /audit-logs", cors(auth(rateLimitRead(http.HandlerFunc(h.ListAuditLogs)))))
 
 	// Write operations - rate limited per tenant
-	mux.Handle("POST /zones", auth(rateLimitWrite(admin(http.HandlerFunc(h.CreateZone)))))
-	mux.Handle("POST /zones/{id}/records", auth(rateLimitWrite(admin(http.HandlerFunc(h.CreateRecord)))))
+	mux.Handle("POST /zones", cors(auth(rateLimitWrite(admin(http.HandlerFunc(h.CreateZone))))))
+	mux.Handle("POST /zones/{id}/records", cors(auth(rateLimitWrite(admin(http.HandlerFunc(h.CreateRecord))))))
 
 	// Delete operations - more restrictive
-	mux.Handle("DELETE /zones/{id}", auth(rateLimitDeleteZone(admin(http.HandlerFunc(h.DeleteZone)))))
-	mux.Handle("DELETE /zones/{zone_id}/records/{id}", auth(rateLimitDeleteRecord(admin(http.HandlerFunc(h.DeleteRecord)))))
+	mux.Handle("DELETE /zones/{id}", cors(auth(rateLimitDeleteZone(admin(http.HandlerFunc(h.DeleteZone))))))
+	mux.Handle("DELETE /zones/{zone_id}/records/{id}", cors(auth(rateLimitDeleteRecord(admin(http.HandlerFunc(h.DeleteRecord))))))
 }
 
 // Metrics handles Prometheus metrics scraping requests.
@@ -125,7 +143,11 @@ func (h *Handler) ListAuditLogs(w http.ResponseWriter, r *http.Request) {
 // CreateZone handles POST /zones requests.
 func (h *Handler) CreateZone(w http.ResponseWriter, r *http.Request) {
 	var zone domain.Zone
-	if err := json.NewDecoder(r.Body).Decode(&zone); err != nil {
+	if !validateContentType(r) {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxBodySize)).Decode(&zone); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -212,7 +234,11 @@ func (h *Handler) ListRecordsForZone(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) CreateRecord(w http.ResponseWriter, r *http.Request) {
 	zoneID := r.PathValue("id")
 	var record domain.Record
-	if err := json.NewDecoder(r.Body).Decode(&record); err != nil {
+	if !validateContentType(r) {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxBodySize)).Decode(&record); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -3,7 +3,6 @@ package api
 
 import (
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -73,6 +72,15 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /zones", cors(auth(rateLimitRead(http.HandlerFunc(h.ListZones)))))
 	mux.Handle("GET /zones/{id}/records", cors(auth(rateLimitRead(http.HandlerFunc(h.ListRecordsForZone)))))
 	mux.Handle("GET /audit-logs", cors(auth(rateLimitRead(http.HandlerFunc(h.ListAuditLogs)))))
+	mux.Handle("OPTIONS /zones", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
+	mux.Handle("OPTIONS /zones/{id}/records", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
+	mux.Handle("OPTIONS /audit-logs", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
 
 	// Write operations - rate limited per tenant
 	mux.Handle("POST /zones", cors(auth(rateLimitWrite(admin(http.HandlerFunc(h.CreateZone))))))
@@ -81,6 +89,12 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Delete operations - more restrictive
 	mux.Handle("DELETE /zones/{id}", cors(auth(rateLimitDeleteZone(admin(http.HandlerFunc(h.DeleteZone))))))
 	mux.Handle("DELETE /zones/{zone_id}/records/{id}", cors(auth(rateLimitDeleteRecord(admin(http.HandlerFunc(h.DeleteRecord))))))
+	mux.Handle("OPTIONS /zones/{id}", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
+	mux.Handle("OPTIONS /zones/{zone_id}/records/{id}", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})))
 }
 
 // Metrics handles Prometheus metrics scraping requests.
@@ -149,7 +163,7 @@ func (h *Handler) CreateZone(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
 		return
 	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, maxBodySize)).Decode(&zone); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodySize)).Decode(&zone); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -240,7 +254,7 @@ func (h *Handler) CreateRecord(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
 		return
 	}
-	if err := json.NewDecoder(io.LimitReader(r.Body, maxBodySize)).Decode(&record); err != nil {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodySize)).Decode(&record); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -24,10 +24,7 @@ func validateContentType(r *http.Request) bool {
 	}
 	// Parse media type: split on ";," then trim and lowercase for exact comparison
 	mediaType := strings.TrimSpace(strings.Split(contentType, ";")[0])
-	if strings.ToLower(mediaType) == "application/json" {
-		return true
-	}
-	return false
+	return strings.ToLower(mediaType) == "application/json"
 }
 
 // Handler handles HTTP requests for zone and record management.

--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -72,13 +72,13 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /zones", cors(auth(rateLimitRead(http.HandlerFunc(h.ListZones)))))
 	mux.Handle("GET /zones/{id}/records", cors(auth(rateLimitRead(http.HandlerFunc(h.ListRecordsForZone)))))
 	mux.Handle("GET /audit-logs", cors(auth(rateLimitRead(http.HandlerFunc(h.ListAuditLogs)))))
-	mux.Handle("OPTIONS /zones", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("OPTIONS /zones", cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})))
-	mux.Handle("OPTIONS /zones/{id}/records", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("OPTIONS /zones/{id}/records", cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})))
-	mux.Handle("OPTIONS /audit-logs", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("OPTIONS /audit-logs", cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})))
 
@@ -89,10 +89,10 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Delete operations - more restrictive
 	mux.Handle("DELETE /zones/{id}", cors(auth(rateLimitDeleteZone(admin(http.HandlerFunc(h.DeleteZone))))))
 	mux.Handle("DELETE /zones/{zone_id}/records/{id}", cors(auth(rateLimitDeleteRecord(admin(http.HandlerFunc(h.DeleteRecord))))))
-	mux.Handle("OPTIONS /zones/{id}", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("OPTIONS /zones/{id}", cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})))
-	mux.Handle("OPTIONS /zones/{zone_id}/records/{id}", cors(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux.Handle("OPTIONS /zones/{zone_id}/records/{id}", cors(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})))
 }

--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -16,13 +16,18 @@ import (
 const maxBodySize = 1 << 20 // 1MB
 
 // validateContentType checks if Content-Type is application/json.
-// Returns true if empty (backward compat) or has JSON prefix.
+// Returns true if empty (backward compat) or exactly "application/json".
 func validateContentType(r *http.Request) bool {
 	contentType := r.Header.Get("Content-Type")
 	if contentType == "" {
 		return true
 	}
-	return strings.HasPrefix(strings.TrimSpace(strings.Split(contentType, ";")[0]), "application/json")
+	// Parse media type: split on ";," then trim and lowercase for exact comparison
+	mediaType := strings.TrimSpace(strings.Split(contentType, ";")[0])
+	if strings.ToLower(mediaType) == "application/json" {
+		return true
+	}
+	return false
 }
 
 // Handler handles HTTP requests for zone and record management.

--- a/internal/adapters/api/handler_test.go
+++ b/internal/adapters/api/handler_test.go
@@ -545,3 +545,92 @@ func TestMetrics(t *testing.T) {
 		t.Errorf(status200Err, w.Code)
 	}
 }
+
+func TestCreateZone_InvalidContentType(t *testing.T) {
+	svc := &mockDNSService{}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	body := []byte(`{"name": "test.com."}`)
+	req := httptest.NewRequest("POST", zonesPath, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "text/plain")
+	req = withTenant(req, testTenantID)
+	w := httptest.NewRecorder()
+
+	handler.CreateZone(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("Expected status 415, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateRecord_InvalidContentType(t *testing.T) {
+	svc := &mockDNSService{}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	body := []byte(`{"name": "www.test.com.", "type": "A", "content": "1.2.3.4"}`)
+	req := httptest.NewRequest("POST", recordsPath, bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "text/plain")
+	req = withTenant(req, testTenantID)
+	w := httptest.NewRecorder()
+
+	handler.CreateRecord(w, req)
+
+	if w.Code != http.StatusUnsupportedMediaType {
+		t.Errorf("Expected status 415, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateZone_BodySizeLimit(t *testing.T) {
+	svc := &mockDNSService{}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	// Create a payload larger than 1MB
+	largeBody := make([]byte, maxBodySize+100)
+	for i := range largeBody {
+		largeBody[i] = ' '
+	}
+	// Make it valid JSON by wrapping in object
+	largeBody[0] = '{'
+	largeBody[len(largeBody)-1] = '}'
+
+	req := httptest.NewRequest("POST", zonesPath, bytes.NewBuffer(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = withTenant(req, testTenantID)
+	w := httptest.NewRecorder()
+
+	handler.CreateZone(w, req)
+
+	// Should fail due to body size limit (io.EOF from LimitReader exhaustion)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateRecord_BodySizeLimit(t *testing.T) {
+	svc := &mockDNSService{}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	// Create a payload larger than 1MB
+	largeBody := make([]byte, maxBodySize+100)
+	for i := range largeBody {
+		largeBody[i] = ' '
+	}
+	largeBody[0] = '{'
+	largeBody[len(largeBody)-1] = '}'
+
+	req := httptest.NewRequest("POST", recordsPath, bytes.NewBuffer(largeBody))
+	req.Header.Set("Content-Type", "application/json")
+	req = withTenant(req, testTenantID)
+	w := httptest.NewRecorder()
+
+	handler.CreateRecord(w, req)
+
+	// Should fail due to body size limit
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %d. Body: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -86,11 +86,15 @@ func CORSMiddleware(config *CORSConfig) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
-			// Set CORS headers for all responses
-			if len(config.AllowedOrigins) == 1 && config.AllowedOrigins[0] == "*" {
-				w.Header().Set("Access-Control-Allow-Origin", "*")
-			} else if origin != "" && config.isOriginAllowed(origin) {
-				w.Header().Set("Access-Control-Allow-Origin", origin)
+			// Set CORS headers for allowed origins
+			if config.isOriginAllowed(origin) {
+				if len(config.AllowedOrigins) == 1 && config.AllowedOrigins[0] == "*" {
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					// Credentials header required for specific origins (not wildcard)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
 			}
 
 			// Handle preflight OPTIONS

--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -62,8 +62,17 @@ func DefaultCORSConfig() *CORSConfig {
 	if origins == "" {
 		origins = "*"
 	}
+	// Parse and trim each origin, ignoring empty strings
+	rawOrigins := strings.Split(origins, ",")
+	allowed := make([]string, 0, len(rawOrigins))
+	for _, o := range rawOrigins {
+		trimmed := strings.TrimSpace(o)
+		if trimmed != "" {
+			allowed = append(allowed, trimmed)
+		}
+	}
 	return &CORSConfig{
-		AllowedOrigins: strings.Split(origins, ","),
+		AllowedOrigins: allowed,
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 		AllowedHeaders: []string{"Authorization", "Content-Type", "X-Real-IP", "X-Forwarded-For"},
 		MaxAge:         86400,

--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -91,17 +91,32 @@ func (c *CORSConfig) isOriginAllowed(origin string) bool {
 
 // CORSMiddleware returns middleware that adds CORS headers.
 func CORSMiddleware(config *CORSConfig) func(http.Handler) http.Handler {
+	// Check if wildcard is present and if it's the only entry
+	hasWildcard := false
+	for _, allowed := range config.AllowedOrigins {
+		if allowed == "*" {
+			hasWildcard = true
+			break
+		}
+	}
+	isWildcardOnly := len(config.AllowedOrigins) == 1 && config.AllowedOrigins[0] == "*"
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
 			// Set CORS headers for allowed origins
 			if config.isOriginAllowed(origin) {
-				if len(config.AllowedOrigins) == 1 && config.AllowedOrigins[0] == "*" {
+				if isWildcardOnly {
+					// Wildcard only: set * and credentials are safe
+					w.Header().Set("Access-Control-Allow-Origin", "*")
+				} else if hasWildcard {
+					// Wildcard mixed with specific origins: use * but NO credentials
+					// (browsers don't allow credentials with wildcard)
 					w.Header().Set("Access-Control-Allow-Origin", "*")
 				} else {
+					// Specific origins only: set exact origin and credentials
 					w.Header().Set("Access-Control-Allow-Origin", origin)
-					// Credentials header required for specific origins (not wildcard)
 					w.Header().Set("Access-Control-Allow-Credentials", "true")
 				}
 			}

--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -101,7 +101,7 @@ func CORSMiddleware(config *CORSConfig) func(http.Handler) http.Handler {
 			if r.Method == http.MethodOptions {
 				w.Header().Set("Access-Control-Allow-Methods", strings.Join(config.AllowedMethods, ", "))
 				w.Header().Set("Access-Control-Allow-Headers", strings.Join(config.AllowedHeaders, ", "))
-				w.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", config.MaxAge))
+				w.Header().Set("Access-Control-Max-Age", strconv.Itoa(config.MaxAge))
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}

--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -44,6 +46,65 @@ func isFromTrustedProxy(remoteAddr string) bool {
 		}
 	}
 	return false
+}
+
+// CORSConfig holds CORS settings from environment.
+type CORSConfig struct {
+	AllowedOrigins []string
+	AllowedMethods []string
+	AllowedHeaders []string
+	MaxAge         int
+}
+
+// DefaultCORSConfig creates config from CORS_ALLOWED_ORIGINS env var (comma-separated, or "*" for all).
+func DefaultCORSConfig() *CORSConfig {
+	origins := os.Getenv("CORS_ALLOWED_ORIGINS")
+	if origins == "" {
+		origins = "*"
+	}
+	return &CORSConfig{
+		AllowedOrigins: strings.Split(origins, ","),
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders: []string{"Authorization", "Content-Type", "X-Real-IP", "X-Forwarded-For"},
+		MaxAge:         86400,
+	}
+}
+
+// isOriginAllowed checks if the origin is allowed.
+func (c *CORSConfig) isOriginAllowed(origin string) bool {
+	for _, allowed := range c.AllowedOrigins {
+		if allowed == "*" || allowed == origin {
+			return true
+		}
+	}
+	return false
+}
+
+// CORSMiddleware returns middleware that adds CORS headers.
+func CORSMiddleware(config *CORSConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			// Set CORS headers for all responses
+			if len(config.AllowedOrigins) == 1 && config.AllowedOrigins[0] == "*" {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else if origin != "" && config.isOriginAllowed(origin) {
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+
+			// Handle preflight OPTIONS
+			if r.Method == http.MethodOptions {
+				w.Header().Set("Access-Control-Allow-Methods", strings.Join(config.AllowedMethods, ", "))
+				w.Header().Set("Access-Control-Allow-Headers", strings.Join(config.AllowedHeaders, ", "))
+				w.Header().Set("Access-Control-Max-Age", fmt.Sprintf("%d", config.MaxAge))
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // AuthMiddleware validates API keys and injects tenant context into requests.

--- a/internal/adapters/api/middleware_test.go
+++ b/internal/adapters/api/middleware_test.go
@@ -273,3 +273,167 @@ func TestRateLimitMiddleware(t *testing.T) {
 		}
 	})
 }
+
+func TestCORSMiddleware(t *testing.T) {
+	t.Run("AllowAllOrigins", func(t *testing.T) {
+		config := &CORSConfig{
+			AllowedOrigins: []string{"*"},
+			AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+			AllowedHeaders: []string{"Authorization", "Content-Type"},
+			MaxAge:         86400,
+		}
+		middleware := CORSMiddleware(config)
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/zones", nil)
+		req.Header.Set("Origin", "https://example.com")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+		if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+			t.Errorf("expected *, got %s", rr.Header().Get("Access-Control-Allow-Origin"))
+		}
+	})
+
+	t.Run("SpecificOrigin", func(t *testing.T) {
+		config := &CORSConfig{
+			AllowedOrigins: []string{"https://example.com", "https://app.example.org"},
+			AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+			AllowedHeaders: []string{"Authorization", "Content-Type"},
+			MaxAge:         86400,
+		}
+		middleware := CORSMiddleware(config)
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/zones", nil)
+		req.Header.Set("Origin", "https://example.com")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+		if rr.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+			t.Errorf("expected https://example.com, got %s", rr.Header().Get("Access-Control-Allow-Origin"))
+		}
+		if rr.Header().Get("Access-Control-Allow-Credentials") != "true" {
+			t.Errorf("expected true, got %s", rr.Header().Get("Access-Control-Allow-Credentials"))
+		}
+	})
+
+	t.Run("DisallowedOrigin", func(t *testing.T) {
+		config := &CORSConfig{
+			AllowedOrigins: []string{"https://allowed.com"},
+			AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+			AllowedHeaders: []string{"Authorization", "Content-Type"},
+			MaxAge:         86400,
+		}
+		middleware := CORSMiddleware(config)
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/zones", nil)
+		req.Header.Set("Origin", "https://malicious.com")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+		if rr.Header().Get("Access-Control-Allow-Origin") != "" {
+			t.Errorf("expected empty, got %s", rr.Header().Get("Access-Control-Allow-Origin"))
+		}
+	})
+
+	t.Run("NoOrigin", func(t *testing.T) {
+		config := &CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedMethods: []string{"GET", "POST", "OPTIONS"},
+			AllowedHeaders: []string{"Authorization", "Content-Type"},
+			MaxAge:         86400,
+		}
+		middleware := CORSMiddleware(config)
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("GET", "/zones", nil)
+		// No Origin header set
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", rr.Code)
+		}
+		// No CORS headers when no origin
+		if rr.Header().Get("Access-Control-Allow-Origin") != "" {
+			t.Errorf("expected empty, got %s", rr.Header().Get("Access-Control-Allow-Origin"))
+		}
+	})
+
+	t.Run("PreflightOptions", func(t *testing.T) {
+		config := &CORSConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedMethods: []string{"GET", "POST", "DELETE", "OPTIONS"},
+			AllowedHeaders: []string{"Authorization", "Content-Type", "X-Request-ID"},
+			MaxAge:         3600,
+		}
+		middleware := CORSMiddleware(config)
+		handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		req := httptest.NewRequest("OPTIONS", "/zones", nil)
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+		req.Header.Set("Access-Control-Request-Headers", "Authorization, Content-Type")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", rr.Code)
+		}
+		if rr.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+			t.Errorf("expected https://example.com, got %s", rr.Header().Get("Access-Control-Allow-Origin"))
+		}
+		if rr.Header().Get("Access-Control-Allow-Methods") != "GET, POST, DELETE, OPTIONS" {
+			t.Errorf("unexpected Access-Control-Allow-Methods: %s", rr.Header().Get("Access-Control-Allow-Methods"))
+		}
+		if rr.Header().Get("Access-Control-Allow-Headers") != "Authorization, Content-Type, X-Request-ID" {
+			t.Errorf("unexpected Access-Control-Allow-Headers: %s", rr.Header().Get("Access-Control-Allow-Headers"))
+		}
+		if rr.Header().Get("Access-Control-Max-Age") != "3600" {
+			t.Errorf("expected 3600, got %s", rr.Header().Get("Access-Control-Max-Age"))
+		}
+	})
+}
+
+func TestDefaultCORSConfig(t *testing.T) {
+	t.Run("DefaultWildcard", func(t *testing.T) {
+		// This test relies on CORS_ALLOWED_ORIGINS not being set
+		t.Setenv("CORS_ALLOWED_ORIGINS", "")
+		config := DefaultCORSConfig()
+		if len(config.AllowedOrigins) != 1 || config.AllowedOrigins[0] != "*" {
+			t.Errorf("expected [*], got %v", config.AllowedOrigins)
+		}
+		if config.MaxAge != 86400 {
+			t.Errorf("expected 86400, got %d", config.MaxAge)
+		}
+	})
+
+	t.Run("MultipleOrigins", func(t *testing.T) {
+		t.Setenv("CORS_ALLOWED_ORIGINS", "https://a.com,https://b.com,https://c.com")
+		config := DefaultCORSConfig()
+		if len(config.AllowedOrigins) != 3 {
+			t.Errorf("expected 3 origins, got %d", len(config.AllowedOrigins))
+		}
+	})
+}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1143,6 +1143,13 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 		resBuffer.Reset()
 		resBuffer.HasNames = true
 		_ = response.Write(resBuffer)
+		// If still too large (e.g., due to large EDNS options like padding), remove OPT entirely
+		if resBuffer.Position() > maxSize {
+			response.Resources = nil
+			resBuffer.Reset()
+			resBuffer.HasNames = true
+			_ = response.Write(resBuffer)
+		}
 	}
 
 	resData := resBuffer.Buf[:resBuffer.Position()]

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1132,7 +1132,14 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 		response.Header.TruncatedMessage = true
 		response.Answers = nil
 		response.Authorities = nil
-		response.Resources = nil
+		// RFC 6891: Preserve OPT records (type 41) when truncating
+		var optRecords []packet.DNSRecord
+		for _, res := range response.Resources {
+			if res.Type == packet.OPT {
+				optRecords = append(optRecords, res)
+			}
+		}
+		response.Resources = optRecords
 		resBuffer.Reset()
 		resBuffer.HasNames = true
 		_ = response.Write(resBuffer)

--- a/internal/dns/server/server_internal_test.go
+++ b/internal/dns/server/server_internal_test.go
@@ -36,3 +36,120 @@ func TestQueryTypeToRecordType(t *testing.T) {
 		}
 	}
 }
+
+func TestTruncationPreservesOPTRecords(t *testing.T) {
+	// Create a response with OPT records and other resources
+	response := &packet.DNSPacket{
+		Header: packet.DNSHeader{
+			TruncatedMessage: false,
+		},
+		Answers:    []packet.DNSRecord{},
+		Authorities: []packet.DNSRecord{},
+		Resources: []packet.DNSRecord{
+			// Regular A record
+			{Type: packet.A, Name: "www.example.com.", TTL: 300},
+			// OPT record (EDNS) - type 41
+			{Type: packet.OPT, Name: ".", TTL: 0},
+			// Another regular record
+			{Type: packet.CNAME, Name: "example.com.", TTL: 300},
+		},
+	}
+
+	// Simulate the truncation logic from handlePacket
+	// This is the filtering logic that should preserve only OPT records
+	response.Header.TruncatedMessage = true
+	response.Answers = nil
+	response.Authorities = nil
+
+	// RFC 6891: Preserve OPT records (type 41) when truncating
+	var optRecords []packet.DNSRecord
+	for _, res := range response.Resources {
+		if res.Type == packet.OPT {
+			optRecords = append(optRecords, res)
+		}
+	}
+	response.Resources = optRecords
+
+	// Verify only OPT records remain
+	if len(response.Resources) != 1 {
+		t.Errorf("expected 1 resource after truncation, got %d", len(response.Resources))
+	}
+	if len(response.Resources) > 0 && response.Resources[0].Type != packet.OPT {
+		t.Errorf("expected OPT record, got %v", response.Resources[0].Type)
+	}
+	if response.Header.TruncatedMessage != true {
+		t.Errorf("expected TruncatedMessage to be true")
+	}
+}
+
+func TestTruncationWithNoOPTRecords(t *testing.T) {
+	// Create a response with only regular records (no OPT)
+	response := &packet.DNSPacket{
+		Header: packet.DNSHeader{
+			TruncatedMessage: false,
+		},
+		Answers:    []packet.DNSRecord{},
+		Authorities: []packet.DNSRecord{},
+		Resources: []packet.DNSRecord{
+			{Type: packet.A, Name: "www.example.com.", TTL: 300},
+			{Type: packet.CNAME, Name: "example.com.", TTL: 300},
+		},
+	}
+
+	// Simulate truncation logic
+	response.Header.TruncatedMessage = true
+	response.Answers = nil
+	response.Authorities = nil
+
+	var optRecords []packet.DNSRecord
+	for _, res := range response.Resources {
+		if res.Type == packet.OPT {
+			optRecords = append(optRecords, res)
+		}
+	}
+	response.Resources = optRecords
+
+	// When no OPT records exist, Resources should be empty
+	if len(response.Resources) != 0 {
+		t.Errorf("expected 0 resources when no OPT records exist, got %d", len(response.Resources))
+	}
+}
+
+func TestTruncationPreservesMultipleOPTRecords(t *testing.T) {
+	// Test when there are multiple OPT records (edge case)
+	response := &packet.DNSPacket{
+		Header: packet.DNSHeader{
+			TruncatedMessage: false,
+		},
+		Answers:    []packet.DNSRecord{},
+		Authorities: []packet.DNSRecord{},
+		Resources: []packet.DNSRecord{
+			{Type: packet.A, Name: "www.example.com.", TTL: 300},
+			{Type: packet.OPT, Name: ".", TTL: 0},
+			{Type: packet.OPT, Name: ".", TTL: 0},
+			{Type: packet.CNAME, Name: "example.com.", TTL: 300},
+		},
+	}
+
+	// Apply truncation filtering
+	response.Header.TruncatedMessage = true
+	response.Answers = nil
+	response.Authorities = nil
+
+	var optRecords []packet.DNSRecord
+	for _, res := range response.Resources {
+		if res.Type == packet.OPT {
+			optRecords = append(optRecords, res)
+		}
+	}
+	response.Resources = optRecords
+
+	if len(response.Resources) != 2 {
+		t.Errorf("expected 2 OPT records, got %d", len(response.Resources))
+	}
+	for i, res := range response.Resources {
+		if res.Type != packet.OPT {
+			t.Errorf("resource[%d] = %v, expected OPT", i, res.Type)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **Issue #117**: Add Content-Type validation before JSON parsing (returns 415 if not `application/json`)
- **Issue #109**: Add 1MB request body size limit using `io.LimitReader` to prevent memory exhaustion
- **Issue #108**: Add CORS middleware configurable via `CORS_ALLOWED_ORIGINS` env var, handles preflight OPTIONS
- **Issue #100**: Preserve OPT records (type 41) during truncation per RFC 6891

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/adapters/api/... ./internal/dns/server/...` passes (29 tests)
- [x] Manual CORS test: `curl -X OPTIONS http://localhost:8080/zones -H "Origin: example.com"` returns CORS headers
- [x] Manual Content-Type test: POST with `Content-Type: text/plain` returns 415
- [x] Manual body limit test: Send JSON > 1MB is rejected gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable CORS for protected API routes (wildcard and origin-specific options).
  * API request validation: rejects non-JSON content types (415) and oversized bodies (400).

* **Bug Fixes**
  * DNS truncation now preserves EDNS(0) OPT records and retries trimming if still oversized.

* **Tests**
  * Added tests for CORS behavior, request validation, and DNS truncation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->