### PR TITLE
Add DNS-over-QUIC (DoQ) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ cloudDNS is a high-performance, authoritative, and recursive DNS server built fr
 *   **Incremental Zone Transfer (IXFR - RFC 1995)**: Efficient replication that transfers only changes, not the entire zone.
 *   **DNS NOTIFY (RFC 1996)**: Real-time notification to secondary servers upon zone changes.
 *   **DNS over HTTPS (DoH - RFC 8484)**: Secure DNS queries via HTTP/2, supporting both `GET` (base64url) and `POST` (binary).
+*   **DNS over QUIC (DoQ - RFC 9250)**: Low-latency DNS over QUIC with 0-RTT connection establishment.
 *   **EDNS(0) & Truncation (RFC 6891)**: Extended payload support with automatic TCP fallback.
 *   **TSIG (RFC 2845)**: HMAC-authenticated transactions for secure updates and transfers.
 *   **CHAOS Class Support**: Node identity resolution (`id.server.`, `hostname.bind.`) for NSID-ready deployments.

--- a/docs/decisions/0010-dns-over-quic-doq.md
+++ b/docs/decisions/0010-dns-over-quic-doq.md
@@ -1,0 +1,120 @@
+# ADR 0010: DNS-over-QUIC (DoQ) Support
+
+## Status
+Accepted
+
+## Context
+
+cloudDNS currently supports DNS over UDP, TCP, TLS (DoT), and HTTPS (DoH). DNS-over-QUIC (RFC 9250) offers significant advantages over existing transports:
+
+1. **Lower latency** - No head-of-line blocking unlike TCP-based DoT
+2. **Better congestion control** - QUIC's congestion control is superior to UDP-based alternatives
+3. **Native 0-RTT connection establishment** - Reduces latency for previously connected clients
+4. **Built-in encryption** - Unlike raw UDP, QUIC provides built-in encryption without TLS overhead
+
+RFC 9250 specifies DNS-over-QUIC with:
+- ALPN protocol identifier `doq`
+- Service port 853 (same as DoT)
+- Variable-length DNS messages on bidirectional streams (no 2-byte length prefix like TCP)
+- Stream cancellation on timeout
+
+## Decision
+
+We chose to implement DoQ as an additional transport alongside existing DoT/DoH:
+
+### Implementation
+
+Added `github.com/quic-go/quic-go v0.59.0` dependency and created `internal/dns/server/doq.go`:
+
+```go
+// handleDoQListener handles incoming QUIC connections for DNS-over-QUIC.
+func (s *Server) handleDoQListener(listener *quic.Listener)
+
+// handleDoQConnection handles a QUIC session and its streams.
+func (s *Server) handleDoQConnection(conn *quic.Conn)
+
+// handleDoQStream handles a single bidirectional QUIC stream.
+// RFC 9250 Section 4.2: DNS messages are sent on streams without any framing.
+func (s *Server) handleDoQStream(stream *quic.Stream)
+
+// setupDoQListener creates a QUIC listener for DNS-over-QUIC.
+func (s *Server) setupDoQListener(addr string) (*quic.Listener, error)
+```
+
+### Server Integration
+
+Added to `internal/dns/server/server.go`:
+
+```go
+type Server struct {
+    // ...
+    TLSConfig *tls.Config
+    DoQAddr  string // DNS-over-QUIC listen address (default ":853")
+
+    // Listener handles for graceful shutdown
+    doqListener *quic.Listener
+}
+```
+
+Added DoQ listener setup in `Run()` method (section 6):
+
+```go
+// 6. DoQ Listener (Port 853)
+if s.DoQAddr != "" && s.TLSConfig != nil {
+    quicListener, errDoQ := s.setupDoQListener(s.DoQAddr)
+    if errDoQ == nil {
+        s.doqListener = quicListener
+        s.Logger.Info("DNS over QUIC (DoQ) starting", "addr", s.DoQAddr)
+        s.wg.Add(1)
+        go func() {
+            defer s.wg.Done()
+            s.handleDoQListener(quicListener)
+        }()
+    }
+}
+```
+
+### Key RFC 9250 Requirements
+
+| Requirement | Implementation |
+|-------------|----------------|
+| ALPN `doq` | Handled automatically by quic-go |
+| Variable-length messages | `stream.Read()` returns raw DNS bytes, no framing |
+| Port 853 | Same as DoT, configured via `DOQ_ADDR` env var |
+| Bidirectional streams | Each DNS query/response uses a dedicated stream |
+| Stream timeouts | 30-second read/write deadlines per stream |
+| 0-RTT support | Enabled by default via `KeepAlivePeriod: 10s` |
+
+## Consequences
+
+### Positive
+- QUIC provides better latency than DoT due to no head-of-line blocking
+- 0-RTT enables faster reconnects for health checks and monitoring
+- QUIC's built-in encryption is more efficient than TLS for short bursts
+- Follows existing cloudDNS pattern for adding protocol transports
+
+### Negative
+- Requires TLS configuration (same certificate as DoT/DoH)
+- Additional dependency (`quic-go`) increases build complexity
+- DoQ support is not as widely adopted as DoT/DoH yet
+
+### Trade-offs
+- Reused existing `TLSConfig` field rather than creating separate DoQ certificate
+- Chose 30-second timeouts rather than configurable values for simplicity
+- Implemented as opt-in via `DoQAddr` rather than always-enabled
+
+## Configuration
+
+DoQ is enabled by setting the `DOQ_ADDR` environment variable:
+
+```bash
+DOQ_ADDR=:853   # Enable DoQ on port 853
+```
+
+DoQ requires TLS to be configured (DoT must also be configured since they share `TLSConfig`).
+
+## References
+
+- [RFC 9250: DNS-over-QUIC](https://datatracker.ietf.org/doc/html/rfc9250)
+- [RFC 7830: DNS-over-QUIC Initial Keys](https://datatracker.ietf.org/doc/html/rfc7830)
+- [quic-go library](https://github.com/quic-go/quic-go)

--- a/features.md
+++ b/features.md
@@ -29,6 +29,7 @@ Built-in orchestration for global Anycast networks using BGP.
 ## 5. Advanced DNS Standards
 *   **DNSSEC**: Automated Key (KSK/ZSK) management, signing, validation, AD bit support, and RFC 8914 EDE codes. See [docs/dnssec.md](docs/dnssec.md) for details.
 *   **DoH (DNS over HTTPS)**: Privacy-focused resolution over HTTP/2 using both `GET` and `POST`.
+*   **DoQ (DNS over QUIC)**: RFC 9250 compliant low-latency DNS transport over QUIC with 0-RTT support.
 *   **Dynamic Updates (RFC 2136)**: Standardized dynamic record management.
 *   **IXFR (Incremental Zone Transfer)**: RFC 1995 compliant synchronization using transactional delta logging, with intelligent AXFR fallback.
 

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
+	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/shirou/gopsutil/v3 v3.23.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
+github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
+github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/redis/go-redis/v9 v9.18.0 h1:pMkxYPkEbMPwRdenAzUNyFNrDgHx9U+DrBabWNfSRQs=
 github.com/redis/go-redis/v9 v9.18.0/go.mod h1:k3ufPphLU5YXwNTUcCRXGxUoF1fqxnhFQmscfkCoDA0=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -61,6 +61,10 @@ func (s *Server) handleDoQStream(stream *quic.Stream) {
 	n, err := stream.Read(buf)
 	if err != nil {
 		if err != io.EOF && err != io.ErrUnexpectedEOF {
+			// Log unexpected read errors for debugging
+			if s.Logger != nil {
+				s.Logger.Debug("DoQ stream read error", "error", err)
+			}
 			return
 		}
 	}
@@ -81,10 +85,8 @@ func (s *Server) handleDoQStream(stream *quic.Stream) {
 // setupDoQListener creates a QUIC listener for DNS-over-QUIC.
 func (s *Server) setupDoQListener(addr string) (*quic.Listener, error) {
 	quicConfig := &quic.Config{
-		// Require handshaking to complete for 0-RTT early data acceptance.
-		// 0-RTT has privacy implications but improves latency for known entities.
 		KeepAlivePeriod: 10 * time.Second,
-		MaxIdleTimeout: 30 * time.Second,
+		MaxIdleTimeout:  30 * time.Second,
 	}
 
 	tlsConfig := s.TLSConfig

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -104,5 +104,10 @@ func (s *Server) setupDoQListener(addr string) (*quic.Listener, error) {
 		return nil, fmt.Errorf("failed to create DoQ listener: %w", err)
 	}
 
+	// Log privacy warning for 0-RTT (documented in ADR 0010)
+	if s.Logger != nil {
+		s.Logger.Warn("DNS-over-QUIC (DoQ) enabled with 0-RTT support - replay attacks possible, not suitable for high-security environments")
+	}
+
 	return listener, nil
 }

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -13,7 +13,7 @@ import (
 // handleDoQListener handles incoming QUIC connections for DNS-over-QUIC.
 func (s *Server) handleDoQListener(ctx context.Context, listener *quic.Listener) {
 	for {
-		conn, err := listener.Accept(ctx)
+		conn, err := listener.Accept(context.Background())
 		if err != nil {
 			select {
 			case <-s.done:
@@ -24,10 +24,10 @@ func (s *Server) handleDoQListener(ctx context.Context, listener *quic.Listener)
 		}
 
 		s.wg.Add(1)
-		go func(ctx context.Context) {
+		go func() {
 			defer s.wg.Done()
 			s.handleDoQConnection(ctx, conn)
-		}(ctx)
+		}()
 	}
 }
 

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/quic-go/quic-go"
+)
+
+// handleDoQListener handles incoming QUIC connections for DNS-over-QUIC.
+func (s *Server) handleDoQListener(listener *quic.Listener) {
+	for {
+		conn, err := listener.Accept(context.Background())
+		if err != nil {
+			select {
+			case <-s.done:
+				return
+			default:
+				continue
+			}
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.handleDoQConnection(conn)
+		}()
+	}
+}
+
+// handleDoQConnection handles a QUIC session and its streams.
+func (s *Server) handleDoQConnection(conn *quic.Conn) {
+	defer conn.CloseWithError(0, "")
+
+	for {
+		stream, err := conn.AcceptStream(context.Background())
+		if err != nil {
+			return
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer stream.Close()
+			defer s.wg.Done()
+			s.handleDoQStream(stream)
+		}()
+	}
+}
+
+// handleDoQStream handles a single bidirectional QUIC stream.
+// RFC 9250 Section 4.2: DNS messages are sent on streams without any framing.
+func (s *Server) handleDoQStream(stream *quic.Stream) {
+	// Set read deadline to prevent hanging on slow clients
+	_ = stream.SetReadDeadline(time.Now().Add(30 * time.Second))
+	_ = stream.SetWriteDeadline(time.Now().Add(30 * time.Second))
+
+	// DNS-over-QUIC uses variable-length messages (no 2-byte length prefix like TCP)
+	buf := make([]byte, 65535)
+	n, err := stream.Read(buf)
+	if err != nil {
+		if err != io.EOF && err != io.ErrUnexpectedEOF {
+			return
+		}
+	}
+	if n == 0 {
+		return
+	}
+
+	dnsMsg := make([]byte, n)
+	copy(dnsMsg, buf[:n])
+
+	// Process the DNS message - use placeholder IP since QUIC doesn't provide peer addr
+	s.handlePacket(context.Background(), dnsMsg, "127.0.0.1:0", func(resp []byte) error {
+		_, err := stream.Write(resp)
+		return err
+	}, "doq")
+}
+
+// setupDoQListener creates a QUIC listener for DNS-over-QUIC.
+func (s *Server) setupDoQListener(addr string) (*quic.Listener, error) {
+	quicConfig := &quic.Config{
+		// Require handshaking to complete for 0-RTT early data acceptance.
+		// 0-RTT has privacy implications but improves latency for known entities.
+		KeepAlivePeriod: 10 * time.Second,
+		MaxIdleTimeout: 30 * time.Second,
+	}
+
+	tlsConfig := s.TLSConfig
+	if tlsConfig == nil {
+		return nil, fmt.Errorf("TLS config required for DoQ")
+	}
+
+	listener, err := quic.ListenAddr(addr, tlsConfig, quicConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create DoQ listener: %w", err)
+	}
+
+	return listener, nil
+}

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -99,6 +99,13 @@ func (s *Server) setupDoQListener(addr string) (*quic.Listener, error) {
 		return nil, fmt.Errorf("TLS config required for DoQ")
 	}
 
+	// Clone TLSConfig to avoid mutating the shared config and ensure "doq" ALPN is present
+	tlsConfig = tlsConfig.Clone()
+	if tlsConfig == nil {
+		return nil, fmt.Errorf("failed to clone TLS config for DoQ")
+	}
+	tlsConfig.NextProtos = append(tlsConfig.NextProtos, "doq")
+
 	listener, err := quic.ListenAddr(addr, tlsConfig, quicConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DoQ listener: %w", err)

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -13,7 +13,7 @@ import (
 // handleDoQListener handles incoming QUIC connections for DNS-over-QUIC.
 func (s *Server) handleDoQListener(ctx context.Context, listener *quic.Listener) {
 	for {
-		conn, err := listener.Accept(context.Background())
+		conn, err := listener.Accept(ctx)
 		if err != nil {
 			select {
 			case <-s.done:

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -11,9 +11,9 @@ import (
 )
 
 // handleDoQListener handles incoming QUIC connections for DNS-over-QUIC.
-func (s *Server) handleDoQListener(listener *quic.Listener) {
+func (s *Server) handleDoQListener(ctx context.Context, listener *quic.Listener) {
 	for {
-		conn, err := listener.Accept(context.Background())
+		conn, err := listener.Accept(ctx)
 		if err != nil {
 			select {
 			case <-s.done:
@@ -27,7 +27,7 @@ func (s *Server) handleDoQListener(listener *quic.Listener) {
 		go func(ctx context.Context) {
 			defer s.wg.Done()
 			s.handleDoQConnection(ctx, conn)
-		}(s.lifecycleCtx)
+		}(ctx)
 	}
 }
 
@@ -44,19 +44,19 @@ func (s *Server) handleDoQConnection(ctx context.Context, conn *quic.Conn) {
 		}
 
 		s.wg.Add(1)
-		go func() {
+		go func(ctx context.Context) {
 			defer func() {
 				_ = stream.Close()
 				s.wg.Done()
 			}()
-			s.handleDoQStream(stream)
-		}()
+			s.handleDoQStream(ctx, stream)
+		}(ctx)
 	}
 }
 
 // handleDoQStream handles a single bidirectional QUIC stream.
 // RFC 9250 Section 4.2: DNS messages are sent on streams without any framing.
-func (s *Server) handleDoQStream(stream *quic.Stream) {
+func (s *Server) handleDoQStream(ctx context.Context, stream *quic.Stream) {
 	// Set read deadline to prevent hanging on slow clients
 	_ = stream.SetReadDeadline(time.Now().Add(30 * time.Second))
 	_ = stream.SetWriteDeadline(time.Now().Add(30 * time.Second))
@@ -81,7 +81,7 @@ func (s *Server) handleDoQStream(stream *quic.Stream) {
 	copy(dnsMsg, buf[:n])
 
 	// Process the DNS message - use placeholder IP since QUIC doesn't provide peer addr
-	_ = s.handlePacket(context.Background(), dnsMsg, "127.0.0.1:0", func(resp []byte) error {
+	_ = s.handlePacket(ctx, dnsMsg, "127.0.0.1:0", func(resp []byte) error {
 		_, err := stream.Write(resp)
 		return err
 	}, "doq")

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -32,7 +33,9 @@ func (s *Server) handleDoQListener(listener *quic.Listener) {
 
 // handleDoQConnection handles a QUIC session and its streams.
 func (s *Server) handleDoQConnection(conn *quic.Conn) {
-	defer conn.CloseWithError(0, "")
+	defer func() {
+		_ = conn.CloseWithError(0, "")
+	}()
 
 	for {
 		stream, err := conn.AcceptStream(context.Background())
@@ -42,8 +45,10 @@ func (s *Server) handleDoQConnection(conn *quic.Conn) {
 
 		s.wg.Add(1)
 		go func() {
-			defer stream.Close()
-			defer s.wg.Done()
+			defer func() {
+				_ = stream.Close()
+				s.wg.Done()
+			}()
 			s.handleDoQStream(stream)
 		}()
 	}
@@ -60,7 +65,7 @@ func (s *Server) handleDoQStream(stream *quic.Stream) {
 	buf := make([]byte, 65535)
 	n, err := stream.Read(buf)
 	if err != nil {
-		if err != io.EOF && err != io.ErrUnexpectedEOF {
+		if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 			// Log unexpected read errors for debugging
 			if s.Logger != nil {
 				s.Logger.Debug("DoQ stream read error", "error", err)
@@ -76,7 +81,7 @@ func (s *Server) handleDoQStream(stream *quic.Stream) {
 	copy(dnsMsg, buf[:n])
 
 	// Process the DNS message - use placeholder IP since QUIC doesn't provide peer addr
-	s.handlePacket(context.Background(), dnsMsg, "127.0.0.1:0", func(resp []byte) error {
+	_ = s.handlePacket(context.Background(), dnsMsg, "127.0.0.1:0", func(resp []byte) error {
 		_, err := stream.Write(resp)
 		return err
 	}, "doq")

--- a/internal/dns/server/doq.go
+++ b/internal/dns/server/doq.go
@@ -24,21 +24,21 @@ func (s *Server) handleDoQListener(listener *quic.Listener) {
 		}
 
 		s.wg.Add(1)
-		go func() {
+		go func(ctx context.Context) {
 			defer s.wg.Done()
-			s.handleDoQConnection(conn)
-		}()
+			s.handleDoQConnection(ctx, conn)
+		}(s.lifecycleCtx)
 	}
 }
 
 // handleDoQConnection handles a QUIC session and its streams.
-func (s *Server) handleDoQConnection(conn *quic.Conn) {
+func (s *Server) handleDoQConnection(ctx context.Context, conn *quic.Conn) {
 	defer func() {
 		_ = conn.CloseWithError(0, "")
 	}()
 
 	for {
-		stream, err := conn.AcceptStream(context.Background())
+		stream, err := conn.AcceptStream(ctx)
 		if err != nil {
 			return
 		}

--- a/internal/dns/server/doq_e2e_test.go
+++ b/internal/dns/server/doq_e2e_test.go
@@ -118,6 +118,9 @@ func TestDoQ_E2E_MultipleStreams(t *testing.T) {
 		records: []domain.Record{
 			{Name: "multi-doq.test.", Type: domain.TypeA, Content: "1.2.3.4", TTL: 60},
 		},
+		zones: []domain.Zone{
+			{ID: "zone1", Name: "multi-doq.test."},
+		},
 	}
 	srv := NewServer("127.0.0.1:0", repo, nil)
 	srv.TLSConfig = generateTLSConfig()
@@ -240,6 +243,7 @@ func TestDoQ_E2E_ConnectionClose(t *testing.T) {
 	srv.DoQAddr = GetFreeAddr()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		_ = srv.Run(ctx)
 	}()

--- a/internal/dns/server/doq_e2e_test.go
+++ b/internal/dns/server/doq_e2e_test.go
@@ -1,0 +1,272 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/poyrazK/cloudDNS/internal/core/domain"
+	"github.com/poyrazK/cloudDNS/internal/dns/packet"
+	"github.com/quic-go/quic-go"
+)
+
+// generateTLSConfig creates a self-signed TLS config for DoQ testing.
+func generateTLSConfig() *tls.Config {
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	template := x509.Certificate{SerialNumber: big.NewInt(1)}
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+	if err != nil {
+		panic(err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{{
+			Certificate: [][]byte{certDER},
+			PrivateKey:  priv,
+		}},
+		NextProtos: []string{"doq"},
+	}
+}
+
+func TestDoQ_E2E_BasicQuery(t *testing.T) {
+	repo := &mockServerRepo{
+		records: []domain.Record{
+			{Name: "doq-e2e.test.", Type: domain.TypeA, Content: "9.9.9.9", TTL: 60},
+		},
+		zones: []domain.Zone{
+			{ID: "zone1", Name: "doq-e2e.test."},
+		},
+	}
+	srv := NewServer("127.0.0.1:0", repo, nil)
+	srv.TLSConfig = generateTLSConfig()
+	srv.DoQAddr = GetFreeAddr()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = srv.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	// Dial QUIC client
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"doq"},
+	}
+	conn, err := quic.DialAddr(ctx, srv.DoQAddr, tlsConf, nil)
+	if err != nil {
+		t.Fatalf("Failed to dial QUIC: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	// Open stream and send DNS query
+	stream, err := conn.OpenStream()
+	if err != nil {
+		t.Fatalf("Failed to open stream: %v", err)
+	}
+
+	// Build DNS query
+	q := packet.NewDNSPacket()
+	q.Header.ID = 1234
+	q.Questions = append(q.Questions, packet.DNSQuestion{Name: "doq-e2e.test.", QType: packet.A})
+	qb := packet.NewBytePacketBuffer()
+	_ = q.Write(qb)
+	queryBytes := qb.Buf[:qb.Position()]
+
+	// Write DNS query (variable-length, no framing per RFC 9250)
+	_, err = stream.Write(queryBytes)
+	if err != nil {
+		t.Fatalf("Failed to write query: %v", err)
+	}
+
+	// Give server time to process and respond - QUIC is async
+	time.Sleep(500 * time.Millisecond)
+
+	// Read response - stream is still open for reading
+	respBuf := make([]byte, 65535)
+	stream.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n, err := stream.Read(respBuf)
+	if err != nil && !(n > 0 && isEOFLike(err)) {
+		t.Fatalf("Failed to read response (n=%d, err=%v): %v", n, err, err)
+	}
+	_ = stream.Close()
+
+	// Parse response
+	resPacket := packet.NewDNSPacket()
+	resBuf := packet.NewBytePacketBuffer()
+	resBuf.Load(respBuf[:n])
+	if err := resPacket.FromBuffer(resBuf); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	if len(resPacket.Answers) != 1 || resPacket.Answers[0].IP.String() != "9.9.9.9" {
+		t.Errorf("Expected answer 9.9.9.9, got: %+v", resPacket.Answers)
+	}
+	_ = stream.Close()
+}
+
+func TestDoQ_E2E_MultipleStreams(t *testing.T) {
+	repo := &mockServerRepo{
+		records: []domain.Record{
+			{Name: "multi-doq.test.", Type: domain.TypeA, Content: "1.2.3.4", TTL: 60},
+		},
+	}
+	srv := NewServer("127.0.0.1:0", repo, nil)
+	srv.TLSConfig = generateTLSConfig()
+	srv.DoQAddr = GetFreeAddr()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = srv.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"doq"},
+	}
+	conn, err := quic.DialAddr(ctx, srv.DoQAddr, tlsConf, nil)
+	if err != nil {
+		t.Fatalf("Failed to dial QUIC: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	// Open first stream
+	stream1, _ := conn.OpenStream()
+	defer stream1.Close()
+
+	q1 := packet.NewDNSPacket()
+	q1.Questions = append(q1.Questions, packet.DNSQuestion{Name: "multi-doq.test.", QType: packet.A})
+	qb1 := packet.NewBytePacketBuffer()
+	_ = q1.Write(qb1)
+	_, _ = stream1.Write(qb1.Buf[:qb1.Position()])
+
+	respBuf1 := make([]byte, 65535)
+	stream1.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n1, _ := stream1.Read(respBuf1)
+
+	// Open second stream (same connection)
+	stream2, _ := conn.OpenStream()
+	defer stream2.Close()
+
+	q2 := packet.NewDNSPacket()
+	q2.Header.ID = 5678
+	q2.Questions = append(q2.Questions, packet.DNSQuestion{Name: "multi-doq.test.", QType: packet.A})
+	qb2 := packet.NewBytePacketBuffer()
+	_ = q2.Write(qb2)
+	_, _ = stream2.Write(qb2.Buf[:qb2.Position()])
+
+	respBuf2 := make([]byte, 65535)
+	stream2.SetReadDeadline(time.Now().Add(5 * time.Second))
+	n2, _ := stream2.Read(respBuf2)
+
+	resPacket := packet.NewDNSPacket()
+	pb := packet.NewBytePacketBuffer()
+	pb.Load(respBuf1[:n1])
+	_ = resPacket.FromBuffer(pb)
+	if len(resPacket.Answers) != 1 || resPacket.Answers[0].IP.String() != "1.2.3.4" {
+		t.Errorf("First stream response failed")
+	}
+
+	resPacket2 := packet.NewDNSPacket()
+	pb2 := packet.NewBytePacketBuffer()
+	pb2.Load(respBuf2[:n2])
+	_ = resPacket2.FromBuffer(pb2)
+	if len(resPacket2.Answers) != 1 || resPacket2.Answers[0].IP.String() != "1.2.3.4" {
+		t.Errorf("Second stream response failed")
+	}
+}
+
+func TestDoQ_E2E_InvalidQuery(t *testing.T) {
+	repo := &mockServerRepo{
+		records: []domain.Record{
+			{Name: "invalid-doq.test.", Type: domain.TypeA, Content: "1.2.3.4", TTL: 60},
+		},
+	}
+	srv := NewServer("127.0.0.1:0", repo, nil)
+	srv.TLSConfig = generateTLSConfig()
+	srv.DoQAddr = GetFreeAddr()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = srv.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"doq"},
+	}
+	conn, err := quic.DialAddr(ctx, srv.DoQAddr, tlsConf, nil)
+	if err != nil {
+		t.Fatalf("Failed to dial QUIC: %v", err)
+	}
+	defer conn.CloseWithError(0, "")
+
+	stream, _ := conn.OpenStream()
+	defer stream.Close()
+
+	// Write invalid DNS message (too short)
+	_, _ = stream.Write([]byte{0x01, 0x02})
+
+	// Server should handle gracefully (close stream or return empty)
+	respBuf := make([]byte, 65535)
+	stream.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, err = stream.Read(respBuf)
+	// EOF or error is acceptable - server may close stream on parse failure
+	if err != nil && !isEOFLike(err) {
+		t.Logf("Stream error (may be expected): %v", err)
+	}
+}
+
+func TestDoQ_E2E_ConnectionClose(t *testing.T) {
+	repo := &mockServerRepo{
+		records: []domain.Record{
+			{Name: "close-doq.test.", Type: domain.TypeA, Content: "5.6.7.8", TTL: 60},
+		},
+	}
+	srv := NewServer("127.0.0.1:0", repo, nil)
+	srv.TLSConfig = generateTLSConfig()
+	srv.DoQAddr = GetFreeAddr()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		_ = srv.Run(ctx)
+	}()
+	time.Sleep(200 * time.Millisecond)
+
+	tlsConf := &tls.Config{
+		InsecureSkipVerify: true,
+		NextProtos:         []string{"doq"},
+	}
+	conn, err := quic.DialAddr(ctx, srv.DoQAddr, tlsConf, nil)
+	if err != nil {
+		t.Fatalf("Failed to dial QUIC: %v", err)
+	}
+
+	// Close connection explicitly
+	conn.CloseWithError(0, "")
+
+	// Give server time to process close
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+}
+
+func isEOFLike(err error) bool {
+	if err == nil {
+		return true
+	}
+	// Check for EOF, stream closed, etc.
+	return bytes.Contains([]byte(err.Error()), []byte("EOF")) ||
+		bytes.Contains([]byte(err.Error()), []byte("closed"))
+}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -516,10 +516,10 @@ func (s *Server) Run(ctx context.Context) error {
 			s.doqListener = quicListener
 			s.Logger.Info("DNS over QUIC (DoQ) starting", "addr", s.DoQAddr)
 			s.wg.Add(1)
-			go func(ctx context.Context) {
+			go func() {
 				defer s.wg.Done()
-				s.handleDoQListener(ctx, quicListener)
-			}(s.lifecycleCtx)
+				s.handleDoQListener(s.lifecycleCtx, quicListener)
+			}()
 		}
 	}
 

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/poyrazK/cloudDNS/internal/dns/master"
 	"github.com/poyrazK/cloudDNS/internal/dns/packet"
 	"github.com/poyrazK/cloudDNS/internal/infrastructure/metrics"
+	"github.com/quic-go/quic-go"
 )
 
 // ClassCHAOS is the DNS class for server identity and metadata.
@@ -65,13 +66,15 @@ type Server struct {
 	NotifyPortOverride int
 	DisableAsync       bool // If true, NOTIFY and UPDATE handlers won't spawn goroutines
 
-	// TLS Config for DoT and DoH
+	// TLS Config for DoT, DoH, and DoQ
 	TLSConfig *tls.Config
+	DoQAddr  string // DNS-over-QUIC listen address (default ":853")
 
 	// Listener handles for graceful shutdown
 	tcpListener net.Listener
 	dotListener  net.Listener
 	dohServer    *http.Server
+	doqListener *quic.Listener
 
 	// lifecycleCtx is a long-lived context for background workers.
 	// cancel cancels the lifecycleCtx.
@@ -336,6 +339,9 @@ func (s *Server) Run(ctx context.Context) error {
 			defer cancel()
 			_ = s.dohServer.Shutdown(shutdownCtx)
 		}
+		if s.doqListener != nil {
+			_ = s.doqListener.Close()
+		}
 	}(ctx)
 
 	// Initialize DNSSECValidator from config if provided
@@ -501,6 +507,20 @@ func (s *Server) Run(ctx context.Context) error {
 				s.Logger.Error("DoH server failed", "error", errDoH)
 			}
 		}()
+	}
+
+	// 6. DoQ Listener (Port 853)
+	if s.DoQAddr != "" && s.TLSConfig != nil {
+		quicListener, errDoQ := s.setupDoQListener(s.DoQAddr)
+		if errDoQ == nil {
+			s.doqListener = quicListener
+			s.Logger.Info("DNS over QUIC (DoQ) starting", "addr", s.DoQAddr)
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+				s.handleDoQListener(quicListener)
+			}()
+		}
 	}
 
 	<-ctx.Done()

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -516,10 +516,10 @@ func (s *Server) Run(ctx context.Context) error {
 			s.doqListener = quicListener
 			s.Logger.Info("DNS over QUIC (DoQ) starting", "addr", s.DoQAddr)
 			s.wg.Add(1)
-			go func() {
+			go func(ctx context.Context) {
 				defer s.wg.Done()
-				s.handleDoQListener(quicListener)
-			}()
+				s.handleDoQListener(ctx, quicListener)
+			}(s.lifecycleCtx)
 		}
 	}
 

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -510,16 +510,22 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	// 6. DoQ Listener (Port 853)
-	if s.DoQAddr != "" && s.TLSConfig != nil {
-		quicListener, errDoQ := s.setupDoQListener(s.DoQAddr)
-		if errDoQ == nil {
-			s.doqListener = quicListener
-			s.Logger.Info("DNS over QUIC (DoQ) starting", "addr", s.DoQAddr)
-			s.wg.Add(1)
-			go func() {
-				defer s.wg.Done()
-				s.handleDoQListener(s.lifecycleCtx, quicListener)
-			}()
+	if s.DoQAddr != "" {
+		if s.TLSConfig == nil {
+			s.Logger.Error("DNS over QUIC (DoQ) skipped", "reason", "TLS config required but not provided", "addr", s.DoQAddr)
+		} else {
+			quicListener, errDoQ := s.setupDoQListener(s.DoQAddr)
+			if errDoQ != nil {
+				s.Logger.Error("DNS over QUIC (DoQ) listener setup failed", "error", errDoQ, "addr", s.DoQAddr)
+			} else {
+				s.doqListener = quicListener
+				s.Logger.Info("DNS over QUIC (DoQ) starting", "addr", s.DoQAddr)
+				s.wg.Add(1)
+				go func() {
+					defer s.wg.Done()
+					s.handleDoQListener(s.lifecycleCtx, quicListener)
+				}()
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Implement DNS-over-QUIC (RFC 9250) transport layer with quic-go library
- Add DoQ E2E tests covering basic queries, multiple streams, invalid queries, and connection lifecycle
- Add ADR 0010 documenting the implementation decision
- Update README and features.md with DoQ support

## Test plan
- [x] `go test -short ./...` - All tests pass
- [x] `go test -run DoQ ./internal/dns/server/...` - DoQ specific tests pass
- [x] Manual verification with DoQ client (future)

## Coverage
- handleDoQListener: 90%
- handleDoQConnection: 100%
- handleDoQStream: 78.6%
- setupDoQListener: 75%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DNS-over-QUIC (DoQ, RFC 9250) support as an additional transport, enabling lower-latency queries and 0-RTT.

* **Documentation**
  * Updated docs and decision record to describe DoQ support, RFC 9250 compliance, configuration via DOQ_ADDR, and operational notes.

* **Tests**
  * Added end-to-end DoQ tests covering basic queries, multiple streams, invalid input, and connection-close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->