### PR TITLE
feat: add HTTPS record type (RFC 9460) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cloudDNS is a high-performance, authoritative, and recursive DNS server built fr
 *   **DNS NOTIFY (RFC 1996)**: Real-time notification to secondary servers upon zone changes.
 *   **DNS over HTTPS (DoH - RFC 8484)**: Secure DNS queries via HTTP/2, supporting both `GET` (base64url) and `POST` (binary).
 *   **DNS over QUIC (DoQ - RFC 9250)**: Low-latency DNS over QUIC with 0-RTT connection establishment.
+*   **HTTPS Records (RFC 9460)**: Service binding hints for HTTP-aware clients with ECH support.
 *   **EDNS(0) & Truncation (RFC 6891)**: Extended payload support with automatic TCP fallback.
 *   **TSIG (RFC 2845)**: HMAC-authenticated transactions for secure updates and transfers.
 *   **CHAOS Class Support**: Node identity resolution (`id.server.`, `hostname.bind.`) for NSID-ready deployments.

--- a/docs/decisions/0011-https-record-support.md
+++ b/docs/decisions/0011-https-record-support.md
@@ -1,0 +1,96 @@
+# ADR 0011: HTTPS Record Type Support
+
+## Status
+Accepted
+
+## Context
+
+cloudDNS currently supports A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, PTR, CAA, and DNSSEC record types. RFC 9460 defines the HTTPS record type (type 65) which provides service binding hints for HTTP-aware clients. This is increasingly important for modern web infrastructure, especially with HTTP/3 adoption where clients use HTTPS records to discover HTTP/3 support and encrypted client hello (ECH) configurations.
+
+## Decision
+
+We implemented HTTPS record type (RFC 9460) as a new record type in cloudDNS.
+
+### Wire Format
+
+HTTPS records follow the SVCB parameter format (RFC 9460 Section 2):
+
+```
++--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+|                  PRIORITY                    |
++--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/                    TARGET                     /
+/                                               /
++--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+/                  SVCB PARAMETERS              /
++--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+```
+
+**Priority 0 = AliasMode**: Target is a domain name alias (no SVCB params allowed)
+**Priority > 0 = ServiceMode**: Full SVCB parameters
+
+### SVCB Parameters (TLV format)
+
+| Key | Name | Description |
+|-----|------|-------------|
+| 1 | alpn | ALPN identifiers (e.g., "h3", "h2") |
+| 2 | no-default | HTTPS-only hint (no HTTP fallback) |
+| 3 | port | Target port (default 443) |
+| 5 | echconfig | ECHConfigList (Encrypted Client Hello) |
+| 6 | ipv4hint | IPv4 address hints |
+| 7 | ipv6hint | IPv6 address hints |
+
+### Implementation
+
+Added to `internal/dns/packet/packet.go`:
+- `HTTPS QueryType = 65` constant
+- `DNSRecord` struct fields: `HTTPSPriority`, `HTTPSTarget`, `HTTPSAlpn`, `HTTPSEchConfig`, `HTTPSIpv4Hint`, `HTTPSIpv6Hint`, `HTTPSPort`, `HTTPSNoDefault`
+- `Read()` case: Parses priority, target, then TLV-encoded SVCB params
+- `Write()` case: Serializes priority, target, then TLV-encoded SVCB params
+
+Added to `internal/core/domain/dns.go`:
+- `TypeHTTPS RecordType = "HTTPS"`
+- `Record` fields: `HTTPSPriority`, `HTTPSHost`, `HTTPSAlpn`, `HTTPSEchConfig`, `HTTPSIpv4Hint`, `HTTPSIpv6Hint`, `HTTPSPort`
+
+Added to `internal/adapters/repository/postgres.go`:
+- `ConvertDomainToPacketRecord`: HTTPS → wire format
+- `ConvertPacketRecordToDomain`: wire format → HTTPS
+
+Added to `internal/dns/server/server.go`:
+- `queryTypeToRecordType()`: HTTPS → TypeHTTPS mapping
+
+## Consequences
+
+### Positive
+- HTTPS record queries now work over all transports (UDP, TCP, DoT, DoH, DoQ)
+- ECH support enables encrypted DNS for privacy-conscious clients
+- HTTP/3 client hints improve performance for modern web infrastructure
+- Follows existing record type patterns (SRV-style with dedicated fields)
+
+### Negative
+- Additional complexity in packet parsing/serialization
+- SVCB parameter parsing adds ~60 lines of code
+
+## Configuration
+
+HTTPS records are created via the REST API like any other record type:
+
+```json
+POST /api/v1/zones/{zone_id}/records
+{
+  "name": "www",
+  "type": "HTTPS",
+  "ttl": 300,
+  "https_priority": 1,
+  "https_host": "service.example.com.",
+  "https_alpn": "h3,h2",
+  "https_port": 443,
+  "https_ipv4hint": "192.0.2.1,192.0.2.2",
+  "https_ech_config": "base64encodeddata..."
+}
+```
+
+## References
+
+- [RFC 9460: HTTPS DNS Records](https://datatracker.ietf.org/doc/html/rfc9460)
+- [RFC 9461: SVCB HTTPS record semantics](https://datatracker.ietf.org/doc/html/rfc9461)

--- a/features.md
+++ b/features.md
@@ -4,7 +4,7 @@ A high-performance, authoritative and recursive DNS server built from scratch in
 
 ## 1. Core DNS Engine (Manual RFC 1035)
 Unlike standard implementations that rely on generic libraries, cloudDNS uses a custom-built packet parser and serializer for maximum control and efficiency.
-*   **Wire Format Mastery**: Full support for A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, PTR, and CAA record types.
+*   **Wire Format Mastery**: Full support for A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, PTR, CAA, and HTTPS record types.
 *   **EDNS(0) Support**: Handles extended DNS payloads and flags.
 *   **CHAOS Class**: Support for `id.server.` and `hostname.bind.` queries for node identification.
 
@@ -30,6 +30,7 @@ Built-in orchestration for global Anycast networks using BGP.
 *   **DNSSEC**: Automated Key (KSK/ZSK) management, signing, validation, AD bit support, and RFC 8914 EDE codes. See [docs/dnssec.md](docs/dnssec.md) for details.
 *   **DoH (DNS over HTTPS)**: Privacy-focused resolution over HTTP/2 using both `GET` and `POST`.
 *   **DoQ (DNS over QUIC)**: RFC 9250 compliant low-latency DNS transport over QUIC with 0-RTT support.
+*   **HTTPS Records (RFC 9460)**: Service binding hints for HTTP-aware clients with Encrypted Client Hello (ECH) support.
 *   **Dynamic Updates (RFC 2136)**: Standardized dynamic record management.
 *   **IXFR (Incremental Zone Transfer)**: RFC 1995 compliant synchronization using transactional delta logging, with intelligent AXFR fallback.
 

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -1080,6 +1080,37 @@ func ConvertPacketRecordToDomain(pRec packet.DNSRecord, zoneID string) (domain.R
 	case packet.CAA:
 		rec.Type = domain.TypeCAA
 		rec.Content = fmt.Sprintf("%d %s \"%s\"", pRec.CAAFlag, pRec.CAATag, pRec.CAAValue)
+	case packet.HTTPS:
+		rec.Type = domain.TypeHTTPS
+		if pRec.HTTPSPriority > 0 {
+			p := int(pRec.HTTPSPriority)
+			rec.HTTPSPriority = &p
+		}
+		rec.HTTPSHost = strings.TrimSuffix(pRec.HTTPSTarget, ".")
+		if len(pRec.HTTPSAlpn) > 0 {
+			rec.HTTPSAlpn = strings.Join(pRec.HTTPSAlpn, ",")
+		}
+		if len(pRec.HTTPSEchConfig) > 0 {
+			rec.HTTPSEchConfig = base64.StdEncoding.EncodeToString(pRec.HTTPSEchConfig)
+		}
+		if len(pRec.HTTPSIpv4Hint) > 0 {
+			var ips []string
+			for _, ip := range pRec.HTTPSIpv4Hint {
+				ips = append(ips, ip.String())
+			}
+			rec.HTTPSIpv4Hint = strings.Join(ips, ",")
+		}
+		if len(pRec.HTTPSIpv6Hint) > 0 {
+			var ips []string
+			for _, ip := range pRec.HTTPSIpv6Hint {
+				ips = append(ips, ip.String())
+			}
+			rec.HTTPSIpv6Hint = strings.Join(ips, ",")
+		}
+		if pRec.HTTPSPort != 0 && pRec.HTTPSPort != 443 {
+			port := int(pRec.HTTPSPort)
+			rec.HTTPSPort = &port
+		}
 	default:
 		return rec, fmt.Errorf("unsupported record type for conversion: %d", pRec.Type)
 	}
@@ -1407,6 +1438,53 @@ func ConvertDomainToPacketRecord(rec domain.Record) (packet.DNSRecord, error) {
 			}
 			pRec.CAATag = matches[2]
 			pRec.CAAValue = unescapeCAAValue(matches[3])
+		}
+	case domain.TypeHTTPS:
+		pRec.Type = packet.HTTPS
+		if rec.HTTPSPriority != nil {
+			p := *rec.HTTPSPriority
+			if p < 0 {
+				p = 0
+			}
+			if p > 65535 {
+				p = 65535
+			}
+			pRec.HTTPSPriority = uint16(p) // #nosec G115
+		}
+		pRec.HTTPSTarget = rec.HTTPSHost
+		if !strings.HasSuffix(pRec.HTTPSTarget, ".") {
+			pRec.HTTPSTarget += "."
+		}
+		if rec.HTTPSAlpn != "" {
+			pRec.HTTPSAlpn = strings.Split(rec.HTTPSAlpn, ",")
+		}
+		if rec.HTTPSEchConfig != "" {
+			if decoded, err := base64.StdEncoding.DecodeString(rec.HTTPSEchConfig); err == nil {
+				pRec.HTTPSEchConfig = decoded
+			}
+		}
+		if rec.HTTPSIpv4Hint != "" {
+			for _, ipStr := range strings.Split(rec.HTTPSIpv4Hint, ",") {
+				ipStr = strings.TrimSpace(ipStr)
+				if ip := net.ParseIP(ipStr); ip != nil {
+					pRec.HTTPSIpv4Hint = append(pRec.HTTPSIpv4Hint, ip)
+				}
+			}
+		}
+		if rec.HTTPSIpv6Hint != "" {
+			for _, ipStr := range strings.Split(rec.HTTPSIpv6Hint, ",") {
+				ipStr = strings.TrimSpace(ipStr)
+				if ip := net.ParseIP(ipStr); ip != nil {
+					pRec.HTTPSIpv6Hint = append(pRec.HTTPSIpv6Hint, ip)
+				}
+			}
+		}
+		if rec.HTTPSPort != nil {
+			p := *rec.HTTPSPort
+			if p < 0 || p > 65535 {
+				p = 443
+			}
+			pRec.HTTPSPort = uint16(p) // #nosec G115
 		}
 
 	default:

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -1111,6 +1111,7 @@ func ConvertPacketRecordToDomain(pRec packet.DNSRecord, zoneID string) (domain.R
 			port := int(pRec.HTTPSPort)
 			rec.HTTPSPort = &port
 		}
+		rec.HTTPSNoDefault = pRec.HTTPSNoDefault
 	default:
 		return rec, fmt.Errorf("unsupported record type for conversion: %d", pRec.Type)
 	}
@@ -1486,6 +1487,7 @@ func ConvertDomainToPacketRecord(rec domain.Record) (packet.DNSRecord, error) {
 			}
 			pRec.HTTPSPort = uint16(p) // #nosec G115
 		}
+		pRec.HTTPSNoDefault = rec.HTTPSNoDefault
 
 	default:
 		return pRec, fmt.Errorf("unsupported record type: %s", rec.Type)

--- a/internal/core/domain/dns.go
+++ b/internal/core/domain/dns.go
@@ -28,6 +28,8 @@ const (
 	TypeSRV RecordType = "SRV"
 	// TypeCAA represents a certification authority authorization record (RFC 6844).
 	TypeCAA RecordType = "CAA"
+	// TypeHTTPS represents an HTTPS record (RFC 9460).
+	TypeHTTPS RecordType = "HTTPS"
 )
 
 // HealthCheckType represents the method used to verify endpoint health.
@@ -87,6 +89,15 @@ type Record struct {
 	HealthCheckType   HealthCheckType `json:"health_check_type,omitempty"`
 	HealthCheckTarget string          `json:"health_check_target,omitempty"`
 	HealthStatus      HealthStatus    `json:"health_status,omitempty"`
+
+	// HTTPS record (RFC 9460) fields
+	HTTPSPriority *int   `json:"https_priority,omitempty"` // 0=AliasMode, >0=ServiceMode
+	HTTPSHost     string `json:"https_host,omitempty"`     // Target domain
+	HTTPSAlpn     string `json:"https_alpn,omitempty"`     // comma-separated ALPNs
+	HTTPSEchConfig string `json:"https_ech_config,omitempty"` // base64-encoded ECH config
+	HTTPSIpv4Hint  string `json:"https_ipv4_hint,omitempty"` // comma-separated IPv4
+	HTTPSIpv6Hint  string `json:"https_ipv6_hint,omitempty"` // comma-separated IPv6
+	HTTPSPort      *int   `json:"https_port,omitempty"`       // default 443
 }
 
 // UpdateAction defines the type of change to apply in an atomic update.

--- a/internal/core/domain/dns.go
+++ b/internal/core/domain/dns.go
@@ -98,6 +98,7 @@ type Record struct {
 	HTTPSIpv4Hint  string `json:"https_ipv4_hint,omitempty"` // comma-separated IPv4
 	HTTPSIpv6Hint  string `json:"https_ipv6_hint,omitempty"` // comma-separated IPv6
 	HTTPSPort      *int   `json:"https_port,omitempty"`       // default 443
+	HTTPSNoDefault bool   `json:"https_no_default,omitempty"` // RFC 9460: don't fall back to HTTP
 }
 
 // UpdateAction defines the type of change to apply in an atomic update.

--- a/internal/dns/packet/https_test.go
+++ b/internal/dns/packet/https_test.go
@@ -1,0 +1,390 @@
+package packet
+
+import (
+	"net"
+	"testing"
+)
+
+func TestHTTPSRecord_ReadWrite(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:  "www.example.com.",
+		Type:  HTTPS,
+		Class: 1,
+		TTL:   300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSAlpn:      []string{"h3", "h2"},
+		HTTPSPort:      8443, // non-default port so it's written
+		HTTPSIpv4Hint:  []net.IP{net.ParseIP("192.0.2.1"), net.ParseIP("192.0.2.2")},
+		HTTPSIpv6Hint:  []net.IP{net.ParseIP("2001:db8::1")},
+		HTTPSEchConfig: []byte{0x00, 0x01, 0x02, 0x03},
+	}
+
+	// Write original record
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record: %v", err)
+	}
+
+	// Read back into a new record
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record: %v", err)
+	}
+
+	// Validate fields
+	if decoded.Name != original.Name {
+		t.Errorf("Name mismatch: got %s, want %s", decoded.Name, original.Name)
+	}
+	if decoded.Type != original.Type {
+		t.Errorf("Type mismatch: got %v, want %v", decoded.Type, original.Type)
+	}
+	if decoded.HTTPSPriority != original.HTTPSPriority {
+		t.Errorf("HTTPSPriority mismatch: got %d, want %d", decoded.HTTPSPriority, original.HTTPSPriority)
+	}
+	if decoded.HTTPSTarget != original.HTTPSTarget {
+		t.Errorf("HTTPSTarget mismatch: got %s, want %s", decoded.HTTPSTarget, original.HTTPSTarget)
+	}
+	if len(decoded.HTTPSAlpn) != len(original.HTTPSAlpn) {
+		t.Errorf("HTTPSAlpn length mismatch: got %d, want %d", len(decoded.HTTPSAlpn), len(original.HTTPSAlpn))
+	}
+	for i, alpn := range decoded.HTTPSAlpn {
+		if alpn != original.HTTPSAlpn[i] {
+			t.Errorf("HTTPSAlpn[%d] mismatch: got %s, want %s", i, alpn, original.HTTPSAlpn[i])
+		}
+	}
+	if decoded.HTTPSPort != original.HTTPSPort {
+		t.Errorf("HTTPSPort mismatch: got %d, want %d", decoded.HTTPSPort, original.HTTPSPort)
+	}
+	if len(decoded.HTTPSIpv4Hint) != len(original.HTTPSIpv4Hint) {
+		t.Errorf("HTTPSIpv4Hint length mismatch: got %d, want %d", len(decoded.HTTPSIpv4Hint), len(original.HTTPSIpv4Hint))
+	}
+	for i, ip := range decoded.HTTPSIpv4Hint {
+		if !ip.Equal(original.HTTPSIpv4Hint[i]) {
+			t.Errorf("HTTPSIpv4Hint[%d] mismatch: got %s, want %s", i, ip, original.HTTPSIpv4Hint[i])
+		}
+	}
+	if len(decoded.HTTPSIpv6Hint) != len(original.HTTPSIpv6Hint) {
+		t.Errorf("HTTPSIpv6Hint length mismatch: got %d, want %d", len(decoded.HTTPSIpv6Hint), len(original.HTTPSIpv6Hint))
+	}
+	for i, ip := range decoded.HTTPSIpv6Hint {
+		if !ip.Equal(original.HTTPSIpv6Hint[i]) {
+			t.Errorf("HTTPSIpv6Hint[%d] mismatch: got %s, want %s", i, ip, original.HTTPSIpv6Hint[i])
+		}
+	}
+	if string(decoded.HTTPSEchConfig) != string(original.HTTPSEchConfig) {
+		t.Errorf("HTTPSEchConfig mismatch: got %v, want %v", decoded.HTTPSEchConfig, original.HTTPSEchConfig)
+	}
+}
+
+func TestHTTPSRecord_AliasMode(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	// Priority 0 = AliasMode (no SVCB params)
+	original := DNSRecord{
+		Name:           "example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority: 0,
+		HTTPSTarget:    "www.example.com.",
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS AliasMode record: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS AliasMode record: %v", err)
+	}
+
+	if decoded.HTTPSPriority != 0 {
+		t.Errorf("HTTPSPriority mismatch: got %d, want 0 (AliasMode)", decoded.HTTPSPriority)
+	}
+	if decoded.HTTPSTarget != original.HTTPSTarget {
+		t.Errorf("HTTPSTarget mismatch: got %s, want %s", decoded.HTTPSTarget, original.HTTPSTarget)
+	}
+	// AliasMode should have no params
+	if len(decoded.HTTPSAlpn) != 0 {
+		t.Errorf("HTTPSAlpn should be empty for AliasMode, got %d", len(decoded.HTTPSAlpn))
+	}
+}
+
+func TestHTTPSRecord_NoDefault(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "https-only.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSNoDefault: true,
+		HTTPSAlpn:      []string{"h3"},
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record with no-default: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record with no-default: %v", err)
+	}
+
+	if !decoded.HTTPSNoDefault {
+		t.Errorf("HTTPSNoDefault should be true")
+	}
+}
+
+func TestHTTPSRecord_DefaultPort(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	// Port 443 is default and should not be written
+	original := DNSRecord{
+		Name:           "www.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSPort:      443, // default
+		HTTPSAlpn:      []string{"h3"},
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record: %v", err)
+	}
+
+	// Read back and verify port is not present (defaults to 0)
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record: %v", err)
+	}
+
+	// Port 443 is default, so it should be 0 when read back (not written)
+	if decoded.HTTPSPort != 0 {
+		t.Errorf("HTTPSPort should be 0 (default) when 443 is not written, got %d", decoded.HTTPSPort)
+	}
+}
+
+func TestHTTPSRecord_Write_OnlyAlpn(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "www.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSAlpn:      []string{"h3", "h2"},
+		// No port, no echconfig, no hints
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record: %v", err)
+	}
+
+	if len(decoded.HTTPSAlpn) != 2 {
+		t.Errorf("HTTPSAlpn length mismatch: got %d, want 2", len(decoded.HTTPSAlpn))
+	}
+	if decoded.HTTPSPort != 0 {
+		t.Errorf("HTTPSPort should be 0, got %d", decoded.HTTPSPort)
+	}
+}
+
+func TestHTTPSRecord_Write_OnlyEchConfig(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "www.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSEchConfig: []byte{0x00, 0x01, 0x02, 0x03, 0x04},
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record: %v", err)
+	}
+
+	if string(decoded.HTTPSEchConfig) != string(original.HTTPSEchConfig) {
+		t.Errorf("HTTPSEchConfig mismatch: got %v, want %v", decoded.HTTPSEchConfig, original.HTTPSEchConfig)
+	}
+}
+
+func TestHTTPSRecord_Write_OnlyIpv4Hint(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "www.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSIpv4Hint:  []net.IP{net.ParseIP("192.0.2.1")},
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record: %v", err)
+	}
+
+	if len(decoded.HTTPSIpv4Hint) != 1 {
+		t.Errorf("HTTPSIpv4Hint length mismatch: got %d, want 1", len(decoded.HTTPSIpv4Hint))
+	}
+	if !decoded.HTTPSIpv4Hint[0].Equal(original.HTTPSIpv4Hint[0]) {
+		t.Errorf("HTTPSIpv4Hint mismatch: got %v, want %v", decoded.HTTPSIpv4Hint[0], original.HTTPSIpv4Hint[0])
+	}
+}
+
+func TestHTTPSRecord_Write_OnlyIpv6Hint(t *testing.T) {
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "www.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSIpv6Hint:  []net.IP{net.ParseIP("2001:db8::1")},
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write HTTPS record: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read HTTPS record: %v", err)
+	}
+
+	if len(decoded.HTTPSIpv6Hint) != 1 {
+		t.Errorf("HTTPSIpv6Hint length mismatch: got %d, want 1", len(decoded.HTTPSIpv6Hint))
+	}
+	if !decoded.HTTPSIpv6Hint[0].Equal(original.HTTPSIpv6Hint[0]) {
+		t.Errorf("HTTPSIpv6Hint mismatch: got %v, want %v", decoded.HTTPSIpv6Hint[0], original.HTTPSIpv6Hint[0])
+	}
+}
+
+func TestHTTPSRecord_ReadWrite_RoundTrip(t *testing.T) {
+	// Test with multiple ALPN values
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "multi-alpn.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            600,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "target.example.com.",
+		HTTPSAlpn:      []string{"h3", "h2", "http/1.1"},
+		HTTPSPort:      443,
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+
+	if len(decoded.HTTPSAlpn) != 3 {
+		t.Errorf("ALPN count mismatch: got %d, want 3", len(decoded.HTTPSAlpn))
+	}
+	for i, alpn := range []string{"h3", "h2", "http/1.1"} {
+		if decoded.HTTPSAlpn[i] != alpn {
+			t.Errorf("ALPN[%d] mismatch: got %s, want %s", i, decoded.HTTPSAlpn[i], alpn)
+		}
+	}
+}
+
+func TestHTTPSRecord_Read_AllParams(t *testing.T) {
+	// Test reading a record with all possible SVCB params
+	buffer := NewBytePacketBuffer()
+
+	original := DNSRecord{
+		Name:           "full.example.com.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "service.example.com.",
+		HTTPSAlpn:      []string{"h3"},
+		HTTPSPort:      8443,
+		HTTPSIpv4Hint:  []net.IP{net.ParseIP("192.0.2.1")},
+		HTTPSIpv6Hint:  []net.IP{net.ParseIP("2001:db8::1")},
+		HTTPSEchConfig: []byte{0x01, 0x02},
+		HTTPSNoDefault: true,
+	}
+
+	_, err := original.Write(buffer)
+	if err != nil {
+		t.Fatalf("Failed to write: %v", err)
+	}
+
+	buffer.Pos = 0
+	decoded := DNSRecord{}
+	err = decoded.Read(buffer)
+	if err != nil {
+		t.Fatalf("Failed to read: %v", err)
+	}
+
+	if decoded.HTTPSNoDefault != true {
+		t.Errorf("HTTPSNoDefault should be true")
+	}
+	if decoded.HTTPSPort != 8443 {
+		t.Errorf("HTTPSPort mismatch: got %d, want 8443", decoded.HTTPSPort)
+	}
+}

--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -4,6 +4,7 @@ package packet
 import (
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/poyrazK/cloudDNS/internal/core/domain"
 )
@@ -664,7 +665,9 @@ func (r *DNSRecord) Read(buffer *BytePacketBuffer) error {
 			remaining -= (3 + int(paramLen))
 			switch key {
 			case 1: // alpn
-				r.HTTPSAlpn = append(r.HTTPSAlpn, string(paramData))
+				for _, a := range strings.Split(string(paramData), ",") {
+					r.HTTPSAlpn = append(r.HTTPSAlpn, a)
+				}
 			case 2: // no-default
 				r.HTTPSNoDefault = true
 			case 3: // port
@@ -674,16 +677,18 @@ func (r *DNSRecord) Read(buffer *BytePacketBuffer) error {
 			case 5: // echconfig
 				r.HTTPSEchConfig = paramData
 			case 6: // ipv4hint
-				if len(paramData)%4 == 0 {
-					for i := 0; i < len(paramData); i += 4 {
-						r.HTTPSIpv4Hint = append(r.HTTPSIpv4Hint, net.IP(paramData[i:i+4]))
-					}
+				if len(paramData)%4 != 0 {
+					return fmt.Errorf("HTTPS ipv4hint: length %d not multiple of 4", len(paramData))
+				}
+				for i := 0; i < len(paramData); i += 4 {
+					r.HTTPSIpv4Hint = append(r.HTTPSIpv4Hint, net.IP(paramData[i:i+4]))
 				}
 			case 7: // ipv6hint
-				if len(paramData)%16 == 0 {
-					for i := 0; i < len(paramData); i += 16 {
-						r.HTTPSIpv6Hint = append(r.HTTPSIpv6Hint, net.IP(paramData[i:i+16]))
-					}
+				if len(paramData)%16 != 0 {
+					return fmt.Errorf("HTTPS ipv6hint: length %d not multiple of 16", len(paramData))
+				}
+				for i := 0; i < len(paramData); i += 16 {
+					r.HTTPSIpv6Hint = append(r.HTTPSIpv6Hint, net.IP(paramData[i:i+16]))
 				}
 			}
 		}
@@ -959,10 +964,19 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Seek(currPos); err != nil { return 0, err }
 	case HTTPS:
+		// AliasMode (priority 0) must not have SVCB params per RFC 9460
+		if r.HTTPSPriority == 0 {
+			hasParams := len(r.HTTPSAlpn) > 0 || (r.HTTPSPort != 0 && r.HTTPSPort != 443) || len(r.HTTPSEchConfig) > 0 || len(r.HTTPSIpv4Hint) > 0 || len(r.HTTPSIpv6Hint) > 0 || r.HTTPSNoDefault
+			if hasParams {
+				return 0, fmt.Errorf("HTTPS AliasMode (priority 0) must not have SVCB params")
+			}
+		}
 		// Calculate SVCB params size first
 		paramsSize := 0
-		for _, alpn := range r.HTTPSAlpn {
-			paramsSize += 1 + 2 + len(alpn) // key(1) + len(2) + value
+		if len(r.HTTPSAlpn) > 0 {
+			// RFC 9460 Section 2.2: multiple ALPNs comma-separated in one param
+			alpnValue := strings.Join(r.HTTPSAlpn, ",")
+			paramsSize += 1 + 2 + len(alpnValue)
 		}
 		if r.HTTPSPort != 0 && r.HTTPSPort != 443 {
 			paramsSize += 1 + 2 + 2 // key(1) + len(2) + port(2)
@@ -987,11 +1001,13 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		// Write Target (length-prefixed)
 		if err := buffer.WriteName(r.HTTPSTarget); err != nil { return 0, err }
 		// Write SVCB params
-		for _, alpn := range r.HTTPSAlpn {
+		// RFC 9460 Section 2.2: multiple ALPNs comma-separated in one param
+		if len(r.HTTPSAlpn) > 0 {
 			if err := buffer.Write(1); err != nil { return 0, err }
-			if err := buffer.Writeu16(uint16(len(alpn))); err != nil { return 0, err }
-			for i := 0; i < len(alpn); i++ {
-				if err := buffer.Write(alpn[i]); err != nil { return 0, err }
+			alpnValue := strings.Join(r.HTTPSAlpn, ",")
+			if err := buffer.Writeu16(uint16(len(alpnValue))); err != nil { return 0, err }
+			for i := 0; i < len(alpnValue); i++ {
+				if err := buffer.Write(alpnValue[i]); err != nil { return 0, err }
 			}
 		}
 		if r.HTTPSPort != 0 && r.HTTPSPort != 443 {

--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -74,6 +74,8 @@ const (
 	TSIG       QueryType = 250
 	// CAA represents a certification authority authorization record (RFC 6844).
 	CAA        QueryType = 257
+	// HTTPS represents an HTTPS record (RFC 9460).
+	HTTPS      QueryType = 65
 )
 
 // EDNS0 Option Codes
@@ -137,6 +139,7 @@ func RecordTypeToQueryType(t domain.RecordType) QueryType {
 	case domain.TypePTR: return PTR
 	case domain.TypeSRV: return SRV
 	case domain.TypeCAA: return CAA
+	case domain.TypeHTTPS: return HTTPS
 	default: return UNKNOWN
 	}
 }
@@ -165,6 +168,7 @@ func (t QueryType) String() string {
 	case TSIG: return "TSIG"
 	case PTR: return "PTR"
 	case CAA: return "CAA"
+	case HTTPS: return "HTTPS"
 	default: return fmt.Sprintf("TYPE%d", t)
 	}
 }
@@ -423,6 +427,15 @@ type DNSRecord struct {
 	CAAFlag  uint8
 	CAATag   string
 	CAAValue string
+	// HTTPS (RFC 9460)
+	HTTPSPriority    uint16
+	HTTPSTarget      string
+	HTTPSAlpn        []string
+	HTTPSEchConfig   []byte
+	HTTPSIpv4Hint    []net.IP
+	HTTPSIpv6Hint    []net.IP
+	HTTPSPort        uint16
+	HTTPSNoDefault   bool
 }
 
 // AddEDE adds an Extended DNS Error (RFC 8914) option to an OPT record.
@@ -628,6 +641,51 @@ func (r *DNSRecord) Read(buffer *BytePacketBuffer) error {
 			if errReadVal != nil { return errReadVal }
 			r.CAAValue = string(valData)
 			if errStep2 := buffer.Step(valLen); errStep2 != nil { return errStep2 }
+		}
+	case HTTPS:
+		if r.HTTPSPriority, err = buffer.Readu16(); err != nil { return err }
+		if r.HTTPSTarget, err = buffer.ReadName(); err != nil { return err }
+		// Parse SVCB TLV parameters until end of data
+		remaining := int(dataLen) - (buffer.Position() - startPos)
+		for remaining > 0 {
+			if remaining < 3 {
+				return fmt.Errorf("HTTPS SVCB param: key+len requires 3 bytes, got %d", remaining)
+			}
+			key, errReadKey := buffer.Read()
+			if errReadKey != nil { return errReadKey }
+			paramLen, errReadLen := buffer.Readu16()
+			if errReadLen != nil { return errReadLen }
+			if int(paramLen) > remaining-3 {
+				return fmt.Errorf("HTTPS SVCB param key %d: length %d exceeds remaining %d", key, paramLen, remaining-3)
+			}
+			paramData, errReadParam := buffer.ReadRange(buffer.Position(), int(paramLen))
+			if errReadParam != nil { return errReadParam }
+			if errStep := buffer.Step(int(paramLen)); errStep != nil { return errStep }
+			remaining -= (3 + int(paramLen))
+			switch key {
+			case 1: // alpn
+				r.HTTPSAlpn = append(r.HTTPSAlpn, string(paramData))
+			case 2: // no-default
+				r.HTTPSNoDefault = true
+			case 3: // port
+				if len(paramData) >= 2 {
+					r.HTTPSPort = uint16(paramData[0])<<8 | uint16(paramData[1]) // #nosec G115
+				}
+			case 5: // echconfig
+				r.HTTPSEchConfig = paramData
+			case 6: // ipv4hint
+				if len(paramData)%4 == 0 {
+					for i := 0; i < len(paramData); i += 4 {
+						r.HTTPSIpv4Hint = append(r.HTTPSIpv4Hint, net.IP(paramData[i:i+4]))
+					}
+				}
+			case 7: // ipv6hint
+				if len(paramData)%16 == 0 {
+					for i := 0; i < len(paramData); i += 16 {
+						r.HTTPSIpv6Hint = append(r.HTTPSIpv6Hint, net.IP(paramData[i:i+16]))
+					}
+				}
+			}
 		}
 	case OPT:
 		r.UDPPayloadSize = r.Class
@@ -896,6 +954,81 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		for i := 0; i < len(r.CAAValue); i++ {
 			if err := buffer.Write(r.CAAValue[i]); err != nil { return 0, err }
 		}
+		currPos := buffer.Position()
+		if err := buffer.Seek(lenPos); err != nil { return 0, err }
+		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
+		if err := buffer.Seek(currPos); err != nil { return 0, err }
+	case HTTPS:
+		// Calculate SVCB params size first
+		paramsSize := 0
+		for _, alpn := range r.HTTPSAlpn {
+			paramsSize += 1 + 2 + len(alpn) // key(1) + len(2) + value
+		}
+		if r.HTTPSPort != 0 && r.HTTPSPort != 443 {
+			paramsSize += 1 + 2 + 2 // key(1) + len(2) + port(2)
+		}
+		if len(r.HTTPSEchConfig) > 0 {
+			paramsSize += 1 + 2 + len(r.HTTPSEchConfig) // key(1) + len(2) + value
+		}
+		if len(r.HTTPSIpv4Hint) > 0 {
+			paramsSize += 1 + 2 + (len(r.HTTPSIpv4Hint) * 4) // key(1) + len(2) + ips
+		}
+		if len(r.HTTPSIpv6Hint) > 0 {
+			paramsSize += 1 + 2 + (len(r.HTTPSIpv6Hint) * 16) // key(1) + len(2) + ips
+		}
+		if r.HTTPSNoDefault {
+			paramsSize += 1 + 2 + 0 // key(1) + len(2) + no value
+		}
+		// Write placeholder for RDLENGTH
+		lenPos := buffer.Position()
+		if err := buffer.Writeu16(0); err != nil { return 0, err }
+		// Write Priority
+		if err := buffer.Writeu16(r.HTTPSPriority); err != nil { return 0, err }
+		// Write Target (length-prefixed)
+		if err := buffer.WriteName(r.HTTPSTarget); err != nil { return 0, err }
+		// Write SVCB params
+		for _, alpn := range r.HTTPSAlpn {
+			if err := buffer.Write(1); err != nil { return 0, err }
+			if err := buffer.Writeu16(uint16(len(alpn))); err != nil { return 0, err }
+			for i := 0; i < len(alpn); i++ {
+				if err := buffer.Write(alpn[i]); err != nil { return 0, err }
+			}
+		}
+		if r.HTTPSPort != 0 && r.HTTPSPort != 443 {
+			if err := buffer.Write(3); err != nil { return 0, err }
+			if err := buffer.Writeu16(2); err != nil { return 0, err }
+			if err := buffer.Writeu16(r.HTTPSPort); err != nil { return 0, err }
+		}
+		if len(r.HTTPSEchConfig) > 0 {
+			if err := buffer.Write(5); err != nil { return 0, err }
+			if err := buffer.Writeu16(uint16(len(r.HTTPSEchConfig))); err != nil { return 0, err }
+			for i := 0; i < len(r.HTTPSEchConfig); i++ {
+				if err := buffer.Write(r.HTTPSEchConfig[i]); err != nil { return 0, err }
+			}
+		}
+		if len(r.HTTPSIpv4Hint) > 0 {
+			if err := buffer.Write(6); err != nil { return 0, err }
+			if err := buffer.Writeu16(uint16(len(r.HTTPSIpv4Hint) * 4)); err != nil { return 0, err }
+			for _, ip := range r.HTTPSIpv4Hint {
+				for _, b := range ip.To4() {
+					if err := buffer.Write(b); err != nil { return 0, err }
+				}
+			}
+		}
+		if len(r.HTTPSIpv6Hint) > 0 {
+			if err := buffer.Write(7); err != nil { return 0, err }
+			if err := buffer.Writeu16(uint16(len(r.HTTPSIpv6Hint) * 16)); err != nil { return 0, err }
+			for _, ip := range r.HTTPSIpv6Hint {
+				for _, b := range ip.To16() {
+					if err := buffer.Write(b); err != nil { return 0, err }
+				}
+			}
+		}
+		if r.HTTPSNoDefault {
+			if err := buffer.Write(2); err != nil { return 0, err }
+			if err := buffer.Writeu16(0); err != nil { return 0, err }
+		}
+		// Rewrite RDLENGTH
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115

--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -665,9 +665,7 @@ func (r *DNSRecord) Read(buffer *BytePacketBuffer) error {
 			remaining -= (3 + int(paramLen))
 			switch key {
 			case 1: // alpn
-				for _, a := range strings.Split(string(paramData), ",") {
-					r.HTTPSAlpn = append(r.HTTPSAlpn, a)
-				}
+				r.HTTPSAlpn = append(r.HTTPSAlpn, strings.Split(string(paramData), ",")...)
 			case 2: // no-default
 				r.HTTPSNoDefault = true
 			case 3: // port
@@ -970,28 +968,6 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 			if hasParams {
 				return 0, fmt.Errorf("HTTPS AliasMode (priority 0) must not have SVCB params")
 			}
-		}
-		// Calculate SVCB params size first
-		paramsSize := 0
-		if len(r.HTTPSAlpn) > 0 {
-			// RFC 9460 Section 2.2: multiple ALPNs comma-separated in one param
-			alpnValue := strings.Join(r.HTTPSAlpn, ",")
-			paramsSize += 1 + 2 + len(alpnValue)
-		}
-		if r.HTTPSPort != 0 && r.HTTPSPort != 443 {
-			paramsSize += 1 + 2 + 2 // key(1) + len(2) + port(2)
-		}
-		if len(r.HTTPSEchConfig) > 0 {
-			paramsSize += 1 + 2 + len(r.HTTPSEchConfig) // key(1) + len(2) + value
-		}
-		if len(r.HTTPSIpv4Hint) > 0 {
-			paramsSize += 1 + 2 + (len(r.HTTPSIpv4Hint) * 4) // key(1) + len(2) + ips
-		}
-		if len(r.HTTPSIpv6Hint) > 0 {
-			paramsSize += 1 + 2 + (len(r.HTTPSIpv6Hint) * 16) // key(1) + len(2) + ips
-		}
-		if r.HTTPSNoDefault {
-			paramsSize += 1 + 2 + 0 // key(1) + len(2) + no value
 		}
 		// Write placeholder for RDLENGTH
 		lenPos := buffer.Position()

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -2297,6 +2297,8 @@ func queryTypeToRecordType(qType packet.QueryType) domain.RecordType {
 		return domain.TypePTR
 	case packet.CAA:
 		return domain.TypeCAA
+	case packet.HTTPS:
+		return domain.TypeHTTPS
 	case packet.DS:
 		return domain.RecordType("DS")
 	case packet.DNSKEY:


### PR DESCRIPTION
## Summary
- Add HTTPS record type (RFC 9460) support with full SVCB parameter handling
- HTTPS records provide service binding hints for HTTP-aware clients
- Supports: priority, target, alpn, port, ipv4hint, ipv6hint, echconfig, no-default
- AliasMode (priority 0) works like CNAME for zone apex

## Changes
- **core/domain**: Added `TypeHTTPS` constant and HTTPS fields to Record struct
- **packet**: Added HTTPS QueryType (65), DNSRecord HTTPS fields, Read/Write wire format
- **repository**: Added HTTPS conversion between domain and wire format
- **server**: Added HTTPS to queryTypeToRecordType mapping
- **docs**: ADR 0011 explaining design decisions and RFC 9460 compliance
- **test**: 10 test cases covering all SVCB params, round-trip, and edge cases

## RFC References
- [RFC 9460: HTTPS DNS Records](https://datatracker.ietf.org/doc/html/rfc9460)
- [RFC 9461: SVCB and HTTPS record semantics](https://datatracker.ietf.org/doc/html/rfc9461)

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [x] `go test -v -run HTTPS ./internal/dns/packet/...` - 10 tests pass