### PR TITLE
fix: eliminate L1 cache defensive copy

### DIFF
--- a/internal/dns/server/cache.go
+++ b/internal/dns/server/cache.go
@@ -53,7 +53,7 @@ func (c *DNSCache) getShard(key string) *cacheShard {
 	return c.shards[h.Sum32()%shardCount]
 }
 
-// Get retrieves a response from the cache. It returns (nil, false) if the key is missing 
+// Get retrieves a response from the cache. It returns (nil, false) if the key is missing
 // or has already expired.
 func (c *DNSCache) Get(key string) ([]byte, bool) {
 	shard := c.getShard(key)
@@ -73,6 +73,31 @@ func (c *DNSCache) Get(key string) ([]byte, bool) {
 	out := make([]byte, len(item.data))
 	copy(out, item.data)
 	return out, true
+}
+
+// GetInto returns the cached data with the transaction ID injected into it.
+// Caller must hold the per-key lock for the duration of send to prevent
+// concurrent mutation of the shared cache entry.
+// The returned slice is the shared cache entry — do not retain after send.
+func (c *DNSCache) GetInto(key string, txID uint16) ([]byte, bool) {
+	shard := c.getShard(key)
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+
+	item, found := shard.items[key]
+	if !found {
+		return nil, false
+	}
+
+	if time.Now().After(item.expiresAt) {
+		return nil, false
+	}
+
+	if len(item.data) >= 2 {
+		item.data[0] = byte(txID >> 8)
+		item.data[1] = byte(txID & 0xFF)
+	}
+	return item.data, true
 }
 
 // Set stores a response in the cache with a specific TTL.

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -915,16 +915,13 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	var cachedData []byte
 	var fromL2 bool
 
-	if cachedData, found := s.Cache.Get(cacheKey); found {
+	if data, found := s.Cache.GetInto(cacheKey, request.Header.ID); found {
 		metrics.CacheOperations.WithLabelValues("l1", "hit").Inc()
 		metrics.QueriesTotal.WithLabelValues(qTypeLabel, "0", protocol).Inc()
 		metrics.QueryDuration.WithLabelValues("cache_l1").Observe(time.Since(start).Seconds())
-		if len(cachedData) >= 2 {
-			cachedData[0] = byte(request.Header.ID >> 8)
-			cachedData[1] = byte(request.Header.ID & 0xFF)
-		}
+		err := sendFn(data)
 		lock.Unlock()
-		return sendFn(cachedData)
+		return err
 	}
 	metrics.CacheOperations.WithLabelValues("l1", "miss").Inc()
 

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -913,7 +913,6 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	lock.Lock()
 
 	var cachedData []byte
-	var fromL2 bool
 
 	if data, found := s.Cache.GetInto(cacheKey, request.Header.ID); found {
 		metrics.CacheOperations.WithLabelValues("l1", "hit").Inc()
@@ -942,13 +941,12 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 			}
 			s.Cache.Set(cacheKey, data, remainingTTL)
 			cachedData = data
-			fromL2 = true
 		}
 	}
 
 	lock.Unlock()
 
-	if fromL2 {
+	if cachedData != nil {
 		return sendFn(cachedData)
 	}
 


### PR DESCRIPTION
## Summary
- Add `Cache.GetInto()` method that injects TXID directly into shared cache entry
- Eliminate ~50MB/s allocations at 100K qps by removing make+copy on L1 hit
- Lock held through send to prevent concurrent mutation

## Changes
- **cache.go**: Add `GetInto()` that injects TXID into shared entry, holds shard RLock
- **server.go**: Use `GetInto()` instead of `Get()` + mutation, keep per-key lock through send

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short ./...` passes