### PR TITLE
fix: infrastructure resource lifecycle (#73, #89)

### DIFF
--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -132,10 +132,28 @@ func run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		// Sane pool settings for Cloud SQL f1-micro (limited RAM and ~25 connections max)
-		db.SetMaxOpenConns(20)
-		db.SetMaxIdleConns(10)
-		db.SetConnMaxLifetime(5 * time.Minute)
+		// Pool settings configurable via env vars with sane defaults for Cloud SQL f1-micro
+		maxOpenConns := 20
+		if v := os.Getenv("DATABASE_MAX_OPEN_CONNS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				maxOpenConns = n
+			}
+		}
+		maxIdleConns := 10
+		if v := os.Getenv("DATABASE_MAX_IDLE_CONNS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				maxIdleConns = n
+			}
+		}
+		connMaxLifetime := 5 * time.Minute
+		if v := os.Getenv("DATABASE_CONN_MAX_LIFETIME_MINUTES"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				connMaxLifetime = time.Duration(n) * time.Minute
+			}
+		}
+		db.SetMaxOpenConns(maxOpenConns)
+		db.SetMaxIdleConns(maxIdleConns)
+		db.SetConnMaxLifetime(connMaxLifetime)
 
 		defer func() { _ = db.Close() }()
 		repo = repository.NewPostgresRepository(db)
@@ -313,6 +331,21 @@ func run(ctx context.Context) error {
 	if routingAdapter != nil {
 		if err := routingAdapter.Stop(); err != nil {
 			logger.Error("BGP speaker stop failed", "error", err)
+		}
+	}
+
+	if redisCache != nil {
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- redisCache.Close()
+		}()
+		select {
+		case err := <-errCh:
+			if err != nil {
+				logger.Error("redis shutdown failed", "error", err)
+			}
+		case <-shutdownCtx.Done():
+			logger.Warn("redis close timed out during shutdown")
 		}
 	}
 

--- a/cmd/clouddns/main_test.go
+++ b/cmd/clouddns/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -254,4 +256,66 @@ func TestRun_ConfigPaths(t *testing.T) {
 			t.Error("Expected error for API bind failure on port 1")
 		}
 	})
+}
+
+func TestDatabasePoolConfigEnvVars(t *testing.T) {
+	origMaxOpen := os.Getenv("DATABASE_MAX_OPEN_CONNS")
+	origMaxIdle := os.Getenv("DATABASE_MAX_IDLE_CONNS")
+	origMaxLifetime := os.Getenv("DATABASE_CONN_MAX_LIFETIME_MINUTES")
+	defer func() {
+		os.Setenv("DATABASE_MAX_OPEN_CONNS", origMaxOpen)
+		os.Setenv("DATABASE_MAX_IDLE_CONNS", origMaxIdle)
+		os.Setenv("DATABASE_CONN_MAX_LIFETIME_MINUTES", origMaxLifetime)
+	}()
+
+	tests := []struct {
+		name                      string
+		maxOpen, maxIdle, minutes string
+		wantOpen, wantIdle        int
+		wantLifetime              time.Duration
+	}{
+		{"defaults", "", "", "", 20, 10, 5 * time.Minute},
+		{"custom values", "50", "5", "10", 50, 5, 10 * time.Minute},
+		{"invalid open falls back", "abc", "", "", 20, 10, 5 * time.Minute},
+		{"invalid idle falls back", "", "xyz", "", 20, 10, 5 * time.Minute},
+		{"zero idle allowed", "", "0", "", 20, 0, 5 * time.Minute},
+		{"negative lifetime falls back", "", "", "-1", 20, 10, 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("DATABASE_MAX_OPEN_CONNS", tt.maxOpen)
+			os.Setenv("DATABASE_MAX_IDLE_CONNS", tt.maxIdle)
+			os.Setenv("DATABASE_CONN_MAX_LIFETIME_MINUTES", tt.minutes)
+
+			maxOpenConns := 20
+			if v := os.Getenv("DATABASE_MAX_OPEN_CONNS"); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n > 0 {
+					maxOpenConns = n
+				}
+			}
+			maxIdleConns := 10
+			if v := os.Getenv("DATABASE_MAX_IDLE_CONNS"); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+					maxIdleConns = n
+				}
+			}
+			connMaxLifetime := 5 * time.Minute
+			if v := os.Getenv("DATABASE_CONN_MAX_LIFETIME_MINUTES"); v != "" {
+				if n, err := strconv.Atoi(v); err == nil && n > 0 {
+					connMaxLifetime = time.Duration(n) * time.Minute
+				}
+			}
+
+			if maxOpenConns != tt.wantOpen {
+				t.Errorf("maxOpenConns = %d, want %d", maxOpenConns, tt.wantOpen)
+			}
+			if maxIdleConns != tt.wantIdle {
+				t.Errorf("maxIdleConns = %d, want %d", maxIdleConns, tt.wantIdle)
+			}
+			if connMaxLifetime != tt.wantLifetime {
+				t.Errorf("connMaxLifetime = %v, want %v", connMaxLifetime, tt.wantLifetime)
+			}
+		})
+	}
 }

--- a/internal/dns/server/redis.go
+++ b/internal/dns/server/redis.go
@@ -117,3 +117,8 @@ func (r *RedisCache) PopFromDLQ(ctx context.Context, timeout time.Duration) (str
 func (r *RedisCache) DLQLen(ctx context.Context) (int64, error) {
 	return r.client.LLen(ctx, DLQChannel).Result()
 }
+
+// Close shuts down the Redis client connection.
+func (r *RedisCache) Close() error {
+	return r.client.Close()
+}

--- a/internal/dns/server/redis_test.go
+++ b/internal/dns/server/redis_test.go
@@ -142,3 +142,19 @@ func TestRedisCache_DLQLen(t *testing.T) {
 		t.Errorf("Expected 2, got %d, err=%v", n, err)
 	}
 }
+
+func TestRedisCache_Close(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("Failed to run miniredis: %v", err)
+	}
+	// Don't defer mr.Close() — Close should handle it
+	cache := NewRedisCache(mr.Addr(), "", 0)
+	if err := cache.Close(); err != nil {
+		t.Errorf("Close failed: %v", err)
+	}
+	// After close, Ping should fail
+	if err := cache.Ping(context.Background()); err == nil {
+		t.Errorf("Expected Ping to fail after Close")
+	}
+}


### PR DESCRIPTION
## Summary

Infrastructure resource lifecycle improvements:

| # | Issue | Fix |
|---|-------|-----|
| #73 | Missing database connection pool limits | Add env vars for pool config: `DATABASE_MAX_OPEN_CONNS`, `DATABASE_MAX_IDLE_CONNS`, `DATABASE_CONN_MAX_LIFETIME_MINUTES` |
| #89 | Redis client never closed on shutdown | Add `Close()` method to `RedisCache` and call it in shutdown sequence |

## Changes

- **cmd/clouddns/main.go**: Parse pool config from env vars with defaults; call `redisCache.Close()` on shutdown
- **internal/dns/server/redis.go**: Add `Close()` method

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -short`

Closes #73 #89