### PR TITLE
fix: replace time.After with time.Ticker in dlqRetryWorker (fixes #81)

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -303,14 +303,18 @@ func (s *Server) startInvalidationListener(ctx context.Context) {
 func (s *Server) dlqRetryWorker(ctx context.Context) {
 	s.Logger.Info("starting DLQ retry worker")
 
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			s.Logger.Info("stopping DLQ retry worker")
 			return
-		case <-time.After(5 * time.Second):
+		case <-ticker.C:
 			// Continue to process DLQ after backoff
 		}
+		_ = ctx // ctx is checked via ctx.Done above, not used directly below
 
 		msg, err := s.Redis.PopFromDLQ(ctx, 0)
 		if err != nil {

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -314,7 +314,6 @@ func (s *Server) dlqRetryWorker(ctx context.Context) {
 		case <-ticker.C:
 			// Continue to process DLQ after backoff
 		}
-		_ = ctx // ctx is checked via ctx.Done above, not used directly below
 
 		msg, err := s.Redis.PopFromDLQ(ctx, 0)
 		if err != nil {

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"sort"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/poyrazK/cloudDNS/internal/core/domain"
 	"github.com/poyrazK/cloudDNS/internal/core/ports"
 	"github.com/poyrazK/cloudDNS/internal/dns/packet"
@@ -1389,5 +1391,47 @@ func TestHandleIXFR_TSIGVerifyFailed(t *testing.T) {
 	_ = res.FromBuffer(pb)
 	if res.Header.ResCode != packet.RcodeRefused {
 		t.Errorf("Expected NOTAUTH (5), got %d", res.Header.ResCode)
+	}
+}
+
+func TestDLQRetryWorker_Shutdown(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("Failed to run miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	redisCache := NewRedisCache(mr.Addr(), "", 0)
+	defer redisCache.Close()
+
+	srv := &Server{
+		Redis:  redisCache,
+		Logger: slog.Default(),
+		Cache:  nil,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		srv.dlqRetryWorker(ctx)
+	}()
+
+	// Cancel immediately — worker should exit promptly, not after 5s
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Pass — exited promptly after context cancel
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("dlqRetryWorker did not exit within 500ms after context cancel")
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `time.After(5 * time.Second)` with `time.NewTicker` in `dlqRetryWorker`
- `time.After` creates a new timer on each select iteration; when ctx is cancelled, the select waits for the full 5s timer to fire — blocking shutdown
- `time.Ticker` is created once outside the loop; `select` unblocks immediately on `ctx.Done()` cancellation

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/dns/server/...` passes

Fixes #81