### PR TITLE
fix: close Redis on shutdown + probeTCP ctx support (fixes #89, #87)

### DIFF
--- a/internal/core/services/health_monitor.go
+++ b/internal/core/services/health_monitor.go
@@ -119,7 +119,7 @@ func (m *HealthMonitor) probeRecord(ctx context.Context, rec domain.Record) {
 	case domain.HealthCheckHTTP:
 		status, errMsg = m.probeHTTP(ctx, rec.HealthCheckTarget)
 	case domain.HealthCheckTCP:
-		status, errMsg = m.probeTCP(rec.HealthCheckTarget)
+		status, errMsg = m.probeTCP(ctx, rec.HealthCheckTarget)
 	default:
 		return
 	}
@@ -147,8 +147,9 @@ func (m *HealthMonitor) probeHTTP(ctx context.Context, target string) (domain.He
 	return domain.HealthStatusUnhealthy, fmt.Sprintf("HTTP status: %d", resp.StatusCode)
 }
 
-func (m *HealthMonitor) probeTCP(target string) (domain.HealthStatus, string) {
-	conn, err := net.DialTimeout("tcp", target, 3*time.Second)
+func (m *HealthMonitor) probeTCP(ctx context.Context, target string) (domain.HealthStatus, string) {
+	dialer := &net.Dialer{Timeout: 3 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", target)
 	if err != nil {
 		return domain.HealthStatusUnhealthy, err.Error()
 	}

--- a/internal/core/services/health_monitor_test.go
+++ b/internal/core/services/health_monitor_test.go
@@ -78,13 +78,13 @@ func TestHealthMonitor_ProbeTCP(t *testing.T) {
 
 	m := NewHealthMonitor(nil, nil)
 	target := ts.Listener.Addr().String()
-	status, _ := m.probeTCP(target)
+	status, _ := m.probeTCP(context.Background(), target)
 	if status != domain.HealthStatusHealthy {
 		t.Errorf("Expected Healthy for open TCP port, got %s", status)
 	}
 
 	// Failure Case
-	status, _ = m.probeTCP("localhost:1")
+	status, _ = m.probeTCP(context.Background(), "localhost:1")
 	if status != domain.HealthStatusUnhealthy {
 		t.Errorf("Expected Unhealthy for closed TCP port, got %s", status)
 	}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -371,13 +371,25 @@ func (s *Server) Run(ctx context.Context) error {
 		if s.dotListener != nil {
 			_ = s.dotListener.Close()
 		}
+		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer shutdownCancel()
 		if s.dohServer != nil {
-			shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
 			_ = s.dohServer.Shutdown(shutdownCtx)
 		}
 		if s.doqListener != nil {
 			_ = s.doqListener.Close()
+		}
+		if s.Redis != nil {
+			errCh := make(chan error, 1)
+			go func() { errCh <- s.Redis.Close() }()
+			select {
+			case err := <-errCh:
+				if err != nil {
+					s.Logger.Error("redis shutdown failed", "error", err)
+				}
+			case <-shutdownCtx.Done():
+				s.Logger.Warn("redis close timed out during shutdown")
+			}
 		}
 	}(ctx)
 


### PR DESCRIPTION
## Summary

Two fixes for shutdown gracefulness:

### #89 — Redis client never closed on shutdown
Add `RedisCache.Close()` to the deferred shutdown in `Run()` with a non-blocking timeout pattern:
```go
if s.Redis != nil {
    errCh := make(chan error, 1)
    go func() { errCh <- s.Redis.Close() }()
    select {
    case err := <-errCh:
        if err != nil { s.Logger.Error("redis shutdown failed", "error", err) }
    case <-shutdownCtx.Done():
        s.Logger.Warn("redis close timed out during shutdown")
    }
}
```

### #87 — probeTCP ignores context
Add `ctx context.Context` parameter to `probeTCP`, use `DialContext` instead of `net.DialTimeout` so context cancellation unblocks the TCP dial immediately.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/dns/server/... ./internal/core/services/...` passes

Fixes #89
Fixes #87