### PR TITLE
fix: DNS amplification + health monitor TLS

### DIFF
--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -277,7 +277,7 @@ func run(ctx context.Context) error {
 
 	// 5. Start Health Monitor (Smart Engine)
 	if repo != nil {
-		healthMonitor := services.NewHealthMonitor(repo, logger)
+		healthMonitor := services.NewHealthMonitor(repo, logger, nil)
 		go healthMonitor.Start(runCtx, 30*time.Second)
 	}
 

--- a/internal/core/services/health_monitor.go
+++ b/internal/core/services/health_monitor.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net"
@@ -20,14 +21,23 @@ type HealthMonitor struct {
 	client *http.Client
 }
 
+// HealthMonitorOptions configures optional health monitor behavior.
+type HealthMonitorOptions struct {
+	InsecureSkipVerify bool
+}
+
 // NewHealthMonitor creates a new HealthMonitor with a default HTTP client.
-func NewHealthMonitor(repo ports.DNSRepository, logger *slog.Logger) *HealthMonitor {
+func NewHealthMonitor(repo ports.DNSRepository, logger *slog.Logger, opts *HealthMonitorOptions) *HealthMonitor {
+	client := &http.Client{Timeout: 5 * time.Second}
+	if opts != nil && opts.InsecureSkipVerify {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
 	return &HealthMonitor{
 		repo:   repo,
 		logger: logger,
-		client: &http.Client{
-			Timeout: 5 * time.Second,
-		},
+		client: client,
 	}
 }
 

--- a/internal/core/services/health_monitor_test.go
+++ b/internal/core/services/health_monitor_test.go
@@ -47,7 +47,7 @@ func TestHealthMonitor_ProbeHTTP(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	m := NewHealthMonitor(nil, nil)
+	m := NewHealthMonitor(nil, nil, nil)
 	status, msg := m.probeHTTP(ctx, ts.URL)
 	if status != domain.HealthStatusHealthy {
 		t.Errorf("Expected Healthy, got %s (msg: %s)", status, msg)
@@ -76,7 +76,7 @@ func TestHealthMonitor_ProbeTCP(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	defer ts.Close()
 
-	m := NewHealthMonitor(nil, nil)
+	m := NewHealthMonitor(nil, nil, nil)
 	target := ts.Listener.Addr().String()
 	status, _ := m.probeTCP(context.Background(), target)
 	if status != domain.HealthStatusHealthy {
@@ -92,7 +92,7 @@ func TestHealthMonitor_ProbeTCP(t *testing.T) {
 
 func TestHealthMonitor_RunChecks(t *testing.T) {
 	repo := &testutil.MockRepo{}
-	m := NewHealthMonitor(repo, nil)
+	m := NewHealthMonitor(repo, nil, nil)
 
 	// Mock server for probe target
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -136,7 +136,7 @@ func TestHealthMonitor_RunChecks(t *testing.T) {
 func TestHealthMonitor_Start(t *testing.T) {
 	repo := &testutil.MockRepo{}
 	logger := slog.Default()
-	m := NewHealthMonitor(repo, logger)
+	m := NewHealthMonitor(repo, logger, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately

--- a/internal/core/services/health_monitor_test.go
+++ b/internal/core/services/health_monitor_test.go
@@ -147,3 +147,17 @@ func TestHealthMonitor_Start(t *testing.T) {
 	// Verify no probe was attempted
 	repo.AssertNotCalled(t, "GetRecordsToProbeStreaming")
 }
+
+func TestHealthMonitor_InsecureSkipVerify(t *testing.T) {
+	m := NewHealthMonitor(nil, nil, &HealthMonitorOptions{InsecureSkipVerify: true})
+	if m.client.Transport == nil {
+		t.Fatal("expected custom transport with InsecureSkipVerify")
+	}
+	tr, ok := m.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", m.client.Transport)
+	}
+	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected TLSClientConfig.InsecureSkipVerify to be true")
+	}
+}

--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -55,8 +55,7 @@ func (r *recursiveResolver) getShuffledRoots() []string {
 	_ = binary.Read(rand.Reader, binary.BigEndian, &offset)
 	rotate := int(offset % uint64(len(shuffled)))
 	// Rotate left by rotate positions
-	result := make([]string, len(shuffled))
-	copy(result, append(shuffled[rotate:], shuffled[:rotate]...))
+	result := append(shuffled[rotate:], shuffled[:rotate]...)
 	return result
 }
 

--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	mrand "math/rand"
 	"net"
 	"strings"
 	"time"
@@ -50,11 +49,15 @@ func newRecursiveResolver() *recursiveResolver {
 func (r *recursiveResolver) getShuffledRoots() []string {
 	shuffled := make([]string, len(r.rootHints))
 	copy(shuffled, r.rootHints)
-	// #nosec G404 -- Shuffling root hints for load balancing doesn't require crypto/rand
-	mrand.Shuffle(len(shuffled), func(i, j int) {
-		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
-	})
-	return shuffled
+	// Use crypto/rand to pick a random rotation offset, preventing predictable
+	// root server ordering that could be exploited in amplification attacks.
+	var offset uint64
+	_ = binary.Read(rand.Reader, binary.BigEndian, &offset)
+	rotate := int(offset % uint64(len(shuffled)))
+	// Rotate left by rotate positions
+	result := make([]string, len(shuffled))
+	copy(result, append(shuffled[rotate:], shuffled[:rotate]...))
+	return result
 }
 
 func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.DNSPacket, error) {


### PR DESCRIPTION
## Summary
- **#74 DNS amplification**: Replace `math/rand.Shuffle` in `getShuffledRoots()` with `crypto/rand` rotation to prevent predictable root server ordering
- **#75 Health monitor TLS**: Add `HealthMonitorOptions.InsecureSkipVerify` for environments that need to skip TLS verification

## Changes
- `internal/dns/server/recursive.go`: Round-robin rotation using `crypto/rand.Reader` instead of Fisher-Yates with `math/rand`
- `internal/core/services/health_monitor.go`: New `HealthMonitorOptions` struct with `InsecureSkipVerify` flag, passed through `NewHealthMonitor`
- `cmd/clouddns/main.go`: Updated `NewHealthMonitor` call to pass `nil` options (secure by default)
- `internal/core/services/health_monitor_test.go`: Updated test call sites for new signature + new `TestHealthMonitor_InsecureSkipVerify`

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/dns/server/... ./internal/core/services/... -timeout 30s`

## Related issues
- Fixes #74
- Fixes #75