### PR TITLE
docs: improve EDECodes const block docstring

### DIFF
--- a/internal/core/services/dnssec_validator.go
+++ b/internal/core/services/dnssec_validator.go
@@ -26,7 +26,8 @@ type EDE struct {
 	Info   string
 }
 
-// RFC 8914 Extended DNS Error Codes
+// EDECodes defines RFC 8914 Extended DNS Error Codes used in DNS responses.
+// Error codes cover the full set of DNSSEC validation failure reasons.
 const (
 	EDECodeOther                  uint16 = 0  // Other Error
 	EDECodeUnsupportedDNSKEYAlgo   uint16 = 1  // Unsupported DNSKEY Algorithm


### PR DESCRIPTION
## Summary
- Improve docstring for `EDECodes` const block in `dnssec_validator.go` — replaced generic "RFC 8914 Extended DNS Error Codes" with descriptive text explaining what EDECodes represents

## Test plan
- [x] `go build ./...` — clean build
- [x] `go test ./... -timeout 60s` — all tests pass