### PR TITLE
fix: handleNotify goroutine checks s.done before refreshZone

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1314,6 +1314,7 @@ func (s *Server) handleNotify(ctx context.Context, request *packet.DNSPacket, cl
 	// Trigger async refresh if it's a slave zone
 	if !s.DisableAsync {
 		go func(zoneName string) {
+			// Check for cancellation or shutdown before starting long-running operations.
 			select {
 			case <-ctx.Done():
 				return
@@ -1327,6 +1328,14 @@ func (s *Server) handleNotify(ctx context.Context, request *packet.DNSPacket, cl
 				return
 			}
 			if zone != nil && zone.Role == "slave" {
+				// Check again before refresh to avoid unnecessary work during shutdown.
+				select {
+				case <-ctx.Done():
+					return
+				case <-s.done:
+					return
+				default:
+				}
 				s.refreshZone(ctx, zone)
 			}
 		}(request.Questions[0].Name)


### PR DESCRIPTION
## Summary
- **#80 (Race condition)**: Already fixed in current code — `wg.Add(1)` is correctly called before `go func()` in `health_monitor.go`. No change needed.
- **#82 (Goroutine leak)**: Added `s.done` check before `s.refreshZone()` in the `handleNotify` async goroutine. Previously the goroutine only checked shutdown once at startup, then proceeded to long-running operations without further cancellation checks. Now it exits early during shutdown to avoid unnecessary work.

Fixes #82.

## Test plan
- [x] `go build ./...` — clean build
- [x] `go test ./... -timeout 60s` — all tests pass

---

Note: Issue #80 was investigated and found to be already fixed in the current codebase. The `wg.Add(1)` is correctly called before `go func()` at health_monitor.go:112.