### PR TITLE
fix: add composite indexes for split-horizon DNS queries

### DIFF
--- a/internal/adapters/repository/schema.sql
+++ b/internal/adapters/repository/schema.sql
@@ -92,7 +92,20 @@ CREATE INDEX idx_dns_zones_name_lower ON dns_zones (LOWER(name));
 
 -- Expression index for efficient suffix-match zone lookup via reversed name
 -- Enables PostgreSQL to use index range scan instead of full table scan
-CREATE INDEX idx_dns_zones_name_reverse ON dns_zones (REVERSE(name));
+CREATE INDEX IF NOT EXISTS idx_dns_zones_name_reverse ON dns_zones (REVERSE(name));
+
+-- Composite indexes for split-horizon DNS queries
+-- Covers zone_id + LOWER(name) + type pattern used by DeleteRecordsByNameAndType
+CREATE INDEX IF NOT EXISTS idx_dns_records_zone_name_type ON dns_records(zone_id, LOWER(name), type);
+
+-- Covers zone_id + LOWER(name) pattern used by DeleteRecordsByName
+CREATE INDEX IF NOT EXISTS idx_dns_records_zone_name ON dns_records(zone_id, LOWER(name));
+
+-- Covers zone_id used by DeleteRecordsForZone bulk deletes
+CREATE INDEX IF NOT EXISTS idx_dns_records_zone_id ON dns_records(zone_id);
+
+-- Tenant-scoped zone listing (ListZones, tenant isolation)
+CREATE INDEX IF NOT EXISTS idx_dns_zones_tenant_id ON dns_zones(tenant_id);
 
 CREATE TABLE IF NOT EXISTS api_keys (
     id UUID PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Add composite indexes to `schema.sql` for common tenant-scoped DNS query patterns
- `idx_dns_records_zone_name_type` on `(zone_id, LOWER(name), type)` — covers DeleteRecordsByNameAndType
- `idx_dns_records_zone_name` on `(zone_id, LOWER(name))` — covers DeleteRecordsByName
- `idx_dns_records_zone_id` on `(zone_id)` — covers DeleteRecordsForZone bulk deletes
- `idx_dns_zones_tenant_id` on `(tenant_id)` — covers ListZones tenant isolation

Fixes: #71