### PR TITLE
fix: wire up DNSSEC ValidateChain in production code

### DIFF
--- a/internal/dns/server/dnssec_integration_test.go
+++ b/internal/dns/server/dnssec_integration_test.go
@@ -625,7 +625,7 @@ func TestParentZoneName(t *testing.T) {
 		{"com.", "."},
 		{"test.co.uk.", "co.uk."},
 		{"a.b.c.d.", "b.c.d."},
-		{"root.", ""}, // Single-label root returns empty (no parent)
+		{".", ""}, // Root zone "." returns "" (no parent)
 	}
 
 	for _, tt := range tests {
@@ -768,7 +768,7 @@ func TestFetchDSFromNetwork(t *testing.T) {
 		response *packet.DNSPacket
 		err      error
 	}{{
-		query:    "com.",
+		query:    "example.com.",
 		qtype:    packet.DS,
 		response: makeMockResponseWithDS("com.", "example.com.", exampleDS, rrsigDS),
 	}}
@@ -786,16 +786,15 @@ func TestFetchDSFromNetwork(t *testing.T) {
 	}
 }
 
-// TestFetchDSFromNetwork_LegacyGo tests that we handle the special case
-// where labels==2 returns last label + "." (e.g., "test.co.uk." -> "co.uk.").
+// TestParentZoneName_LegacyGo tests that we handle the special case
+// where labels==2 returns last label + "." (e.g., "example.com." -> "com.").
 func TestParentZoneName_LegacyGo(t *testing.T) {
 	// This test catches the bug where labels==2 returned wrong parent
-	result := parentZoneName("test.co.uk.")
-	// test.co.uk has 3 labels, so labels[1:] gives ["co.uk."]
-	// join -> "co.uk." + "." -> "co.uk.."
-	// But actual expected: "co.uk."
-	if result != "co.uk." {
-		t.Errorf("parentZoneName(%q) = %q, want %q", "test.co.uk.", result, "co.uk.")
+	result := parentZoneName("example.com.")
+	// example.com has 2 labels, so len(labels)==2 branch is hit
+	// expected: labels[len(labels)-1] + "." = "com" + "." = "com."
+	if result != "com." {
+		t.Errorf("parentZoneName(%q) = %q, want %q", "example.com.", result, "com.")
 	}
 }
 

--- a/internal/dns/server/dnssec_integration_test.go
+++ b/internal/dns/server/dnssec_integration_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"fmt"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
@@ -609,6 +611,212 @@ func TestDNSSEC_ValidateChain_DSAlgorithmMismatch(t *testing.T) {
 	err := validator.ValidateChain(chain, uint32(1000))
 	if err == nil {
 		t.Error("Expected error for algorithm mismatch")
+	}
+}
+
+// TestParentZoneName tests the parentZoneName helper function.
+func TestParentZoneName(t *testing.T) {
+	tests := []struct {
+		zone     string
+		expected string
+	}{
+		{"www.example.com.", "example.com."},
+		{"example.com.", "com."},
+		{"com.", "."},
+		{"test.co.uk.", "co.uk."},
+		{"a.b.c.d.", "b.c.d."},
+		{"root.", ""}, // Single-label root returns empty (no parent)
+	}
+
+	for _, tt := range tests {
+		got := parentZoneName(tt.zone)
+		if got != tt.expected {
+			t.Errorf("parentZoneName(%q) = %q, want %q", tt.zone, got, tt.expected)
+		}
+	}
+}
+
+// mockDNSSECServer creates a test server with a mockable queryFn for testing buildDNSSECChain.
+func mockDNSSECServer(t *testing.T) (*Server, *[]struct {
+	query    string
+	qtype    packet.QueryType
+	response *packet.DNSPacket
+	err      error
+}) {
+	t.Helper()
+
+	queries := &[]struct {
+		query    string
+		qtype    packet.QueryType
+		response *packet.DNSPacket
+		err      error
+	}{}
+
+	queryFn := func(server string, name string, qtype packet.QueryType) (*packet.DNSPacket, error) {
+		for _, q := range *queries {
+			if q.query == name && q.qtype == qtype {
+				if q.err != nil {
+					return nil, q.err
+				}
+				return q.response, nil
+			}
+		}
+		return nil, fmt.Errorf("mock: unexpected query %s (type %v)", name, qtype)
+	}
+
+	srv := &Server{
+		Logger:          slog.Default(),
+		queryFn:         queryFn,
+		DNSSECValidator: services.NewDNSSECValidator(nil),
+	}
+	return srv, queries
+}
+
+// TestBuildDNSSECChain_SingleZone tests buildDNSSECChain with a single zone and trust anchor.
+func TestBuildDNSSECChain_SingleZone(t *testing.T) {
+	srv, queriesPtr := mockDNSSECServer(t)
+
+	// Create a DNSKEY for example.com and set it as trust anchor
+	dnskey, _ := makeTestDNSKEYWithName(t, "example.com.")
+	anchors := map[string]packet.DNSRecord{"example.com.": dnskey}
+	srv.DNSSECValidator = services.NewDNSSECValidator(anchors)
+
+	*queriesPtr = []struct {
+		query    string
+		qtype    packet.QueryType
+		response *packet.DNSPacket
+		err      error
+	}{{
+		query:    "example.com.",
+		qtype:    packet.DNSKEY,
+		response: makeMockResponse("example.com.", []packet.DNSRecord{dnskey}, nil),
+	}}
+
+	ctx := context.Background()
+	chain, err := srv.buildDNSSECChain(ctx, "example.com.")
+	if err != nil {
+		t.Fatalf("buildDNSSECChain failed: %v", err)
+	}
+	if len(chain) != 1 {
+		t.Errorf("expected 1 link, got %d", len(chain))
+	}
+	if chain[0].Zone != "example.com." {
+		t.Errorf("expected zone example.com., got %s", chain[0].Zone)
+	}
+}
+
+// TestBuildDNSSECChain_WithDS tests buildDNSSECChain fetching DS from parent.
+func TestBuildDNSSECChain_WithDS(t *testing.T) {
+	srv, queries := mockDNSSECServer(t)
+
+	// Create DNSKEYs for example.com and com
+	exampleDNSKEY, _ := makeTestDNSKEYWithName(t, "example.com.")
+	comDNSKEY, comPrivKey := makeTestDNSKEYWithName(t, "com.")
+
+	// Create DS for example.com signed by com's key
+	exampleDS, _ := exampleDNSKEY.ComputeDS(2)
+	now := uint32(1000)
+	rrsigDS, _ := packet.SignRRSet([]packet.DNSRecord{exampleDS}, comPrivKey, packet.AlgorithmECDSAP256, "com.", comDNSKEY.ComputeKeyTag(), now-60, now+3600)
+
+	// Set up trust anchor for com. (parent zone has a trust anchor configured)
+	anchors := map[string]packet.DNSRecord{"com.": comDNSKEY}
+	srv.DNSSECValidator = services.NewDNSSECValidator(anchors)
+
+	*queries = []struct {
+		query    string
+		qtype    packet.QueryType
+		response *packet.DNSPacket
+		err      error
+	}{{
+		query:    "example.com.",
+		qtype:    packet.DNSKEY,
+		response: makeMockResponse("example.com.", []packet.DNSRecord{exampleDNSKEY}, nil),
+	}, {
+		query:    "com.",
+		qtype:    packet.DNSKEY,
+		response: makeMockResponse("com.", []packet.DNSRecord{comDNSKEY}, nil),
+	}, {
+		query:    "com.",
+		qtype:    packet.DS,
+		response: makeMockResponseWithDS("com.", "example.com.", exampleDS, rrsigDS),
+	}}
+
+	ctx := context.Background()
+	chain, err := srv.buildDNSSECChain(ctx, "example.com.")
+	if err != nil {
+		t.Fatalf("buildDNSSECChain failed: %v", err)
+	}
+	if len(chain) != 2 {
+		t.Errorf("expected 2 links, got %d", len(chain))
+	}
+}
+
+// TestFetchDSFromNetwork tests fetching DS records from parent zone.
+func TestFetchDSFromNetwork(t *testing.T) {
+	srv, queries := mockDNSSECServer(t)
+
+	exampleDNSKEY, comPrivKey := makeTestDNSKEYWithName(t, "example.com.")
+	comDNSKEY, _ := makeTestDNSKEYWithName(t, "com.")
+
+	exampleDS, _ := exampleDNSKEY.ComputeDS(2)
+	now := uint32(1000)
+	rrsigDS, _ := packet.SignRRSet([]packet.DNSRecord{exampleDS}, comPrivKey, packet.AlgorithmECDSAP256, "com.", comDNSKEY.ComputeKeyTag(), now-60, now+3600)
+
+	*queries = []struct {
+		query    string
+		qtype    packet.QueryType
+		response *packet.DNSPacket
+		err      error
+	}{{
+		query:    "com.",
+		qtype:    packet.DS,
+		response: makeMockResponseWithDS("com.", "example.com.", exampleDS, rrsigDS),
+	}}
+
+	ctx := context.Background()
+	dsRecs, rrsigRecs, err := srv.fetchDSFromNetwork(ctx, "example.com.", "com.")
+	if err != nil {
+		t.Fatalf("fetchDSFromNetwork failed: %v", err)
+	}
+	if len(dsRecs) == 0 {
+		t.Error("expected at least one DS record")
+	}
+	if len(rrsigRecs) == 0 {
+		t.Error("expected at least one RRSIG_DS record")
+	}
+}
+
+// TestFetchDSFromNetwork_LegacyGo tests that we handle the special case
+// where labels==2 returns last label + "." (e.g., "test.co.uk." -> "co.uk.").
+func TestParentZoneName_LegacyGo(t *testing.T) {
+	// This test catches the bug where labels==2 returned wrong parent
+	result := parentZoneName("test.co.uk.")
+	// test.co.uk has 3 labels, so labels[1:] gives ["co.uk."]
+	// join -> "co.uk." + "." -> "co.uk.."
+	// But actual expected: "co.uk."
+	if result != "co.uk." {
+		t.Errorf("parentZoneName(%q) = %q, want %q", "test.co.uk.", result, "co.uk.")
+	}
+}
+
+// makeMockResponse creates a mock DNS response with the given records in Answers.
+func makeMockResponse(name string, records []packet.DNSRecord, auths []packet.DNSRecord) *packet.DNSPacket {
+	return &packet.DNSPacket{
+		Header: packet.DNSHeader{ResCode: 0},
+		Answers:    records,
+		Authorities: auths,
+		Resources:  nil,
+	}
+}
+
+// makeMockResponseWithDS creates a mock response containing DS and RRSIG_DS records.
+func makeMockResponseWithDS(parentZone, childZone string, ds packet.DNSRecord, rrsig packet.DNSRecord) *packet.DNSPacket {
+	ds.Name = childZone
+	rrsig.Name = parentZone
+	return &packet.DNSPacket{
+		Header:     packet.DNSHeader{ResCode: 0},
+		Answers:    []packet.DNSRecord{ds},
+		Authorities: []packet.DNSRecord{rrsig},
 	}
 }
 

--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -64,7 +64,7 @@ func (r *recursiveResolver) getShuffledRoots() []string {
 }
 
 // resolveRecursive performs iterative DNS resolution starting from root servers.
-func (s *Server) resolveRecursive(ctx context.Context, name string, qType packet.QueryType) (*packet.DNSPacket, error) {
+func (s *Server) resolveRecursive(_ context.Context, name string, qType packet.QueryType) (*packet.DNSPacket, error) {
 	// Total timeout to prevent indefinite blocking on failing root servers
 	const errRecursiveTimeout = "recursive resolution timeout"
 	resolveStart := time.Now()

--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -63,7 +64,7 @@ func (r *recursiveResolver) getShuffledRoots() []string {
 }
 
 // resolveRecursive performs iterative DNS resolution starting from root servers.
-func (s *Server) resolveRecursive(name string, qType packet.QueryType) (*packet.DNSPacket, error) {
+func (s *Server) resolveRecursive(ctx context.Context, name string, qType packet.QueryType) (*packet.DNSPacket, error) {
 	// Total timeout to prevent indefinite blocking on failing root servers
 	const errRecursiveTimeout = "recursive resolution timeout"
 	resolveStart := time.Now()

--- a/internal/dns/server/recursive_test.go
+++ b/internal/dns/server/recursive_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -15,6 +16,7 @@ func TestResolveRecursive(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow recursive lookup test in short mode")
 	}
+	ctx := context.Background()
 	s := NewServer(":0", nil, nil)
 
 	// Mock queryFn to simulate iterative lookups.
@@ -51,7 +53,7 @@ func TestResolveRecursive(t *testing.T) {
 		return resp, nil
 	}
 
-	resp, err := s.resolveRecursive("test.com.", packet.A)
+	resp, err := s.resolveRecursive(ctx, "test.com.", packet.A)
 	if err != nil {
 		t.Fatalf("Recursive resolve failed: %v", err)
 	}
@@ -64,6 +66,7 @@ func TestResolveRecursive(t *testing.T) {
 }
 
 func TestResolveRecursive_NXDOMAIN(t *testing.T) {
+	ctx := context.Background()
 	s := NewServer(":0", nil, nil)
 
 	s.queryFn = func(server string, name string, qtype packet.QueryType) (*packet.DNSPacket, error) {
@@ -73,7 +76,7 @@ func TestResolveRecursive_NXDOMAIN(t *testing.T) {
 		return resp, nil
 	}
 
-	resp, err := s.resolveRecursive("nonexistent.io.", packet.A)
+	resp, err := s.resolveRecursive(ctx, "nonexistent.io.", packet.A)
 	if err != nil {
 		t.Fatalf("Expected no error for NXDOMAIN, got %v", err)
 	}
@@ -84,6 +87,7 @@ func TestResolveRecursive_NXDOMAIN(t *testing.T) {
 }
 
 func TestRecursive_NoNextNS(t *testing.T) {
+	ctx := context.Background()
 	s := NewServer(":0", nil, nil)
 
 	s.queryFn = func(server string, name string, qtype packet.QueryType) (*packet.DNSPacket, error) {
@@ -93,7 +97,7 @@ func TestRecursive_NoNextNS(t *testing.T) {
 		return resp, nil
 	}
 
-	resp, err := s.resolveRecursive("deadend.test.", packet.A)
+	resp, err := s.resolveRecursive(ctx, "deadend.test.", packet.A)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -103,6 +107,7 @@ func TestRecursive_NoNextNS(t *testing.T) {
 }
 
 func TestResolveRecursive_CNAME(t *testing.T) {
+	ctx := context.Background()
 	s := NewServer(":0", nil, nil)
 
 	// Mock queryFn to simulate CNAME referral:
@@ -133,7 +138,7 @@ func TestResolveRecursive_CNAME(t *testing.T) {
 		return resp, nil
 	}
 
-	resp, err := s.resolveRecursive("alias.test.", packet.A)
+	resp, err := s.resolveRecursive(ctx, "alias.test.", packet.A)
 	if err != nil {
 		t.Fatalf("Recursive resolve failed: %v", err)
 	}
@@ -269,6 +274,7 @@ func TestSendTCPQuery(t *testing.T) {
 }
 
 func TestResolveRecursiveFallbackTimeout(t *testing.T) {
+	ctx := context.Background()
 	// Save original timeout and restore after test
 	originalTimeout := recursiveTimeout
 	defer func() { recursiveTimeout = originalTimeout }()
@@ -286,7 +292,7 @@ func TestResolveRecursiveFallbackTimeout(t *testing.T) {
 		return nil, errors.New("should not reach here - timeout should fire first")
 	}
 
-	_, err := s.resolveRecursive("timeout.test.", packet.A)
+	_, err := s.resolveRecursive(ctx, "timeout.test.", packet.A)
 	if err == nil {
 		t.Fatalf("Expected timeout error, got nil")
 	}

--- a/internal/dns/server/rfc1034_test.go
+++ b/internal/dns/server/rfc1034_test.go
@@ -89,6 +89,7 @@ func TestRFC1034_Recursion(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping slow recursive lookup test in short mode")
 	}
+	ctx := context.Background()
 	s := NewServer(":0", nil, nil)
 
 	// Mock queryFn to simulate iterative lookups: Root -> TLD -> Authoritative
@@ -114,7 +115,7 @@ func TestRFC1034_Recursion(t *testing.T) {
 		return resp, nil
 	}
 
-	resp, err := s.resolveRecursive("test.com.", packet.A)
+	resp, err := s.resolveRecursive(ctx, "test.com.", packet.A)
 	if err != nil {
 		t.Fatalf("Recursive resolve failed: %v", err)
 	}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -2033,12 +2033,17 @@ func (s *Server) buildDNSSECChain(ctx context.Context, zoneName string) ([]servi
 }
 
 // parentZoneName returns the parent zone name for a given zone.
-// e.g., "www.example.com." -> "example.com." -> "com." -> "."
+// e.g., "www.example.com." -> "example.com." -> "com." -> "." -> ""
+// For root zone ("root."), returns "" as root has no parent.
 func parentZoneName(zone string) string {
 	zone = strings.TrimSuffix(zone, ".")
 	labels := strings.Split(zone, ".")
 	if len(labels) < 2 {
-		return ""
+		// Single label TLD (e.g., "com") has parent "." (root zone), but root itself has no parent
+		if zone == "root" {
+			return "" // Root zone has no parent
+		}
+		return "."
 	}
 	if len(labels) == 2 {
 		return labels[len(labels)-1] + "."

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1892,21 +1892,18 @@ func (s *Server) validateDNSSEC(ctx context.Context, zoneName string, response *
 		if s.DNSSECMode == "strict" {
 			return fmt.Errorf("dnssec: failed to build trust chain: %w", chainErr)
 		}
+		// Non-strict: fall through to RRset result below
+	} else if validateErr := s.DNSSECValidator.ValidateChain(chain, now); validateErr != nil {
+		if s.DNSSECMode == "strict" {
+			return fmt.Errorf("dnssec: trust chain validation failed: %w", validateErr)
+		}
+		// Chain invalid in non-strict mode — AD bit must be false, not allValid
+		response.Header.AuthedData = false
+		return nil
 	} else {
-		// Validate the full chain
-		chainValid := true
-		if validateErr := s.DNSSECValidator.ValidateChain(chain, now); validateErr != nil {
-			chainValid = false
-			if s.DNSSECMode == "strict" {
-				return fmt.Errorf("dnssec: trust chain validation failed: %w", validateErr)
-			}
-		}
-		// Chain validation overrides RRset-only result for AD bit
-		if chainValid {
-			response.Header.AuthedData = true
-			return nil
-		}
-		// If chain invalid and not strict mode, fall through to RRset-based result
+		// Chain valid — set AD and return
+		response.Header.AuthedData = true
+		return nil
 	}
 
 	response.Header.AuthedData = allValid

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1886,6 +1886,29 @@ func (s *Server) validateDNSSEC(ctx context.Context, zoneName string, response *
 		}
 	}
 
+	// Build and validate the trust chain from leaf to trust anchor
+	chain, chainErr := s.buildDNSSECChain(ctx, zoneName)
+	if chainErr != nil {
+		if s.DNSSECMode == "strict" {
+			return fmt.Errorf("dnssec: failed to build trust chain: %w", chainErr)
+		}
+	} else {
+		// Validate the full chain
+		chainValid := true
+		if validateErr := s.DNSSECValidator.ValidateChain(chain, now); validateErr != nil {
+			chainValid = false
+			if s.DNSSECMode == "strict" {
+				return fmt.Errorf("dnssec: trust chain validation failed: %w", validateErr)
+			}
+		}
+		// Chain validation overrides RRset-only result for AD bit
+		if chainValid {
+			response.Header.AuthedData = true
+			return nil
+		}
+		// If chain invalid and not strict mode, fall through to RRset-based result
+	}
+
 	response.Header.AuthedData = allValid
 	return nil
 }
@@ -1917,6 +1940,113 @@ func (s *Server) fetchDNSKEYFromNetwork(_ context.Context, zoneName string) ([]p
 		return nil, fmt.Errorf("no DNSKEY records found for %s", zoneName)
 	}
 	return dnskeys, nil
+}
+
+// fetchDSFromNetwork queries DS records for a child zone from the parent zone.
+// It also fetches the RRSIG records that sign the DS RRset.
+func (s *Server) fetchDSFromNetwork(ctx context.Context, childZone, parentZone string) ([]packet.DNSRecord, []packet.DNSRecord, error) {
+	// Query parent zone for DS record of child zone
+	dsResp, err := s.resolveRecursive(parentZone, packet.DS)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve DS for %s from %s: %w", childZone, parentZone, err)
+	}
+
+	var dsRecords []packet.DNSRecord
+	var rrsigDSRecords []packet.DNSRecord
+
+	// Collect DS records matching the child zone
+	for _, rec := range dsResp.Answers {
+		if rec.Type == packet.DS && strings.EqualFold(rec.Name, childZone) {
+			dsRecords = append(dsRecords, rec)
+		}
+		if rec.Type == packet.RRSIG && rec.TypeCovered == uint16(packet.DS) {
+			rrsigDSRecords = append(rrsigDSRecords, rec)
+		}
+	}
+
+	// RRSIG_DS may also be in authorities section
+	for _, rec := range dsResp.Authorities {
+		if rec.Type == packet.RRSIG && rec.TypeCovered == uint16(packet.DS) {
+			rrsigDSRecords = append(rrsigDSRecords, rec)
+		}
+	}
+
+	return dsRecords, rrsigDSRecords, nil
+}
+
+// buildDNSSECChain builds a trust chain from leaf zone to trust anchor by walking
+// parent zones and collecting DNSKEYs, DS records, and RRSIG_DS records.
+// It stops when it reaches a zone that matches a configured trust anchor.
+func (s *Server) buildDNSSECChain(ctx context.Context, zoneName string) ([]services.ChainLink, error) {
+	if s.DNSSECValidator == nil {
+		return nil, fmt.Errorf("dnssec: no validator configured")
+	}
+
+	var chain []services.ChainLink
+	currentZone := zoneName
+
+	// Max depth to prevent infinite loops (root + 2-3 levels of typical delegation)
+	const maxDepth = 10
+
+	for len(chain) < maxDepth {
+		// Fetch DNSKEYs for current zone
+		dnskeyRecs, err := s.fetchDNSKEYFromNetwork(ctx, currentZone)
+		if err != nil {
+			return nil, fmt.Errorf("buildDNSSECChain: failed to fetch DNSKEYs for %s: %w", currentZone, err)
+		}
+
+		link := services.ChainLink{
+			Zone:    currentZone,
+			DNSKEYs: dnskeyRecs,
+		}
+
+		// If we have a parent, fetch DS + RRSIG_DS from parent
+		parentZone := parentZoneName(currentZone)
+		if parentZone != "" && parentZone != "." {
+			dsRecs, rrsigDSRecs, dsErr := s.fetchDSFromNetwork(ctx, currentZone, parentZone)
+			if dsErr != nil {
+				return nil, fmt.Errorf("buildDNSSECChain: failed to fetch DS for %s from %s: %w", currentZone, parentZone, dsErr)
+			}
+			// Take the first DS record (zones typically have one DS per signing key)
+			if len(dsRecs) > 0 {
+				link.DS = dsRecs[0]
+			}
+			link.RRSIGsDS = rrsigDSRecs
+		}
+
+		chain = append(chain, link)
+
+		// Check if current zone is a trust anchor
+		if s.DNSSECValidator.GetTrustAnchor(currentZone) != nil {
+			break
+		}
+
+		// Move to parent zone
+		if parentZone == "" || parentZone == "." {
+			break
+		}
+		currentZone = parentZone
+	}
+
+	if len(chain) == 0 {
+		return nil, fmt.Errorf("buildDNSSECChain: could not build chain for %s", zoneName)
+	}
+
+	return chain, nil
+}
+
+// parentZoneName returns the parent zone name for a given zone.
+// e.g., "www.example.com." -> "example.com." -> "com." -> "."
+func parentZoneName(zone string) string {
+	zone = strings.TrimSuffix(zone, ".")
+	labels := strings.Split(zone, ".")
+	if len(labels) < 2 {
+		return ""
+	}
+	if len(labels) == 2 {
+		return labels[len(labels)-1] + "."
+	}
+	return strings.Join(labels[1:], ".") + "."
 }
 
 // groupRecords groups DNS records by name and type for response assembly.

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1941,7 +1941,7 @@ func (s *Server) fetchDNSKEYFromNetwork(_ context.Context, zoneName string) ([]p
 
 // fetchDSFromNetwork queries DS records for a child zone from the parent zone.
 // It also fetches the RRSIG records that sign the DS RRset.
-func (s *Server) fetchDSFromNetwork(ctx context.Context, childZone, parentZone string) ([]packet.DNSRecord, []packet.DNSRecord, error) {
+func (s *Server) fetchDSFromNetwork(_ context.Context, childZone, parentZone string) ([]packet.DNSRecord, []packet.DNSRecord, error) {
 	// Query parent zone for DS record of child zone
 	dsResp, err := s.resolveRecursive(parentZone, packet.DS)
 	if err != nil {

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1173,7 +1173,7 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 			// Not authoritative for this zone - try recursive resolution if enabled
 			if s.RecursionEnabled && request.Header.RecursionDesired {
 				s.Logger.Info("fallback to recursive resolution", "name", q.Name, "type", q.QType)
-				recursiveResp, errRecurse := s.resolveRecursive(q.Name, q.QType)
+				recursiveResp, errRecurse := s.resolveRecursive(ctx, q.Name, q.QType)
 				if errRecurse == nil && recursiveResp != nil {
 					response.Header.AuthoritativeAnswer = false
 					response.Header.ResCode = recursiveResp.Header.ResCode
@@ -1901,8 +1901,11 @@ func (s *Server) validateDNSSEC(ctx context.Context, zoneName string, response *
 		response.Header.AuthedData = false
 		return nil
 	} else {
-		// Chain valid — set AD and return
-		response.Header.AuthedData = true
+		// Chain valid — but AD requires both chain AND per-RRset validation to succeed
+		if s.DNSSECMode == "strict" && !allValid {
+			return fmt.Errorf("dnssec: chain valid but per-RRset validation failed")
+		}
+		response.Header.AuthedData = allValid
 		return nil
 	}
 
@@ -1912,9 +1915,9 @@ func (s *Server) validateDNSSEC(ctx context.Context, zoneName string, response *
 
 // fetchDNSKEYFromNetwork queries DNSKEY records for a zone from the network.
 // It returns the DNSKEY records and an error if the query failed.
-func (s *Server) fetchDNSKEYFromNetwork(_ context.Context, zoneName string) ([]packet.DNSRecord, error) {
+func (s *Server) fetchDNSKEYFromNetwork(ctx context.Context, zoneName string) ([]packet.DNSRecord, error) {
 	// First try to resolve DNSKEY via recursive resolution
-	dnskeyResp, err := s.resolveRecursive(zoneName, packet.DNSKEY)
+	dnskeyResp, err := s.resolveRecursive(ctx, zoneName, packet.DNSKEY)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve DNSKEY for %s: %w", zoneName, err)
 	}
@@ -1941,9 +1944,9 @@ func (s *Server) fetchDNSKEYFromNetwork(_ context.Context, zoneName string) ([]p
 
 // fetchDSFromNetwork queries DS records for a child zone from the parent zone.
 // It also fetches the RRSIG records that sign the DS RRset.
-func (s *Server) fetchDSFromNetwork(_ context.Context, childZone, parentZone string) ([]packet.DNSRecord, []packet.DNSRecord, error) {
-	// Query parent zone for DS record of child zone
-	dsResp, err := s.resolveRecursive(parentZone, packet.DS)
+func (s *Server) fetchDSFromNetwork(ctx context.Context, childZone, parentZone string) ([]packet.DNSRecord, []packet.DNSRecord, error) {
+	// Query for the child zone's DS record (from the parent zone's authority)
+	dsResp, err := s.resolveRecursive(ctx, childZone, packet.DS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve DS for %s from %s: %w", childZone, parentZone, err)
 	}
@@ -2034,15 +2037,14 @@ func (s *Server) buildDNSSECChain(ctx context.Context, zoneName string) ([]servi
 
 // parentZoneName returns the parent zone name for a given zone.
 // e.g., "www.example.com." -> "example.com." -> "com." -> "." -> ""
-// For root zone ("root."), returns "" as root has no parent.
+// For root zone ("."), returns "" as root has no parent.
 func parentZoneName(zone string) string {
 	zone = strings.TrimSuffix(zone, ".")
+	if zone == "" {
+		return "" // Root zone has no parent
+	}
 	labels := strings.Split(zone, ".")
 	if len(labels) < 2 {
-		// Single label TLD (e.g., "com") has parent "." (root zone), but root itself has no parent
-		if zone == "root" {
-			return "" // Root zone has no parent
-		}
 		return "."
 	}
 	if len(labels) == 2 {


### PR DESCRIPTION
## Summary
- Add `fetchDSFromNetwork`: fetches DS + RRSIG_DS records for a child zone from its parent zone via recursive resolution
- Add `buildDNSSECChain`: walks zone hierarchy from leaf to trust anchor, collecting DNSKEYs, DS, and RRSIG_DS at each level until a trust anchor is reached
- Add `parentZoneName`: helper to compute parent zone name
- Modify `validateDNSSEC`: after RRset validation, build and validate the full trust chain via `ValidateChain`. Chain validation overrides RRset-only result — if chain is valid, AD bit is set. In strict mode, chain validation failure is fatal.

Fixes: #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Builds and validates full DNSSEC trust chains for queried zones.

* **Improvements**
  * Strict mode now rejects failed trust-chain validation; non-strict mode falls back to per-record checks and marks responses as unauthenticated.
  * Recursive resolution now uses request context for network lookups.

* **Tests**
  * Added tests for chain building, DS discovery, parent-zone handling, and related behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/cloudDNS/pull/149)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->