### PR TITLE
perf: eliminate UDP double-copy and zero-copy L1 cache Get

### DIFF
--- a/internal/dns/server/cache.go
+++ b/internal/dns/server/cache.go
@@ -55,6 +55,7 @@ func (c *DNSCache) getShard(key string) *cacheShard {
 
 // Get retrieves a response from the cache. It returns (nil, false) if the key is missing
 // or has already expired.
+// Note: callers must not retain or mutate the returned slice.
 func (c *DNSCache) Get(key string) ([]byte, bool) {
 	shard := c.getShard(key)
 	shard.mu.RLock()
@@ -65,14 +66,11 @@ func (c *DNSCache) Get(key string) ([]byte, bool) {
 		return nil, false
 	}
 
-	// Check if the item is still valid.
 	if time.Now().After(item.expiresAt) {
 		return nil, false
 	}
 
-	out := make([]byte, len(item.data))
-	copy(out, item.data)
-	return out, true
+	return item.data, true
 }
 
 // GetInto returns the cached data with the transaction ID injected into it.
@@ -101,13 +99,18 @@ func (c *DNSCache) GetInto(key string, txID uint16) ([]byte, bool) {
 }
 
 // Set stores a response in the cache with a specific TTL.
+// The input data is copied so the cache owns its own backing array.
 func (c *DNSCache) Set(key string, data []byte, ttl time.Duration) {
 	shard := c.getShard(key)
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 
+	// Copy the data so the caller can mutate their slice without affecting the cache
+	copied := make([]byte, len(data))
+	copy(copied, data)
+
 	shard.items[key] = cacheEntry{
-		data:      data,
+		data:      copied,
 		expiresAt: time.Now().Add(ttl),
 	}
 }

--- a/internal/dns/server/cache_test.go
+++ b/internal/dns/server/cache_test.go
@@ -132,6 +132,9 @@ func TestCacheGetIntoShortData(t *testing.T) {
 	if !found {
 		t.Fatalf("expected to find key %s", key)
 	}
+	if len(data) == 0 {
+		t.Fatalf("expected non-empty data for key %s", key)
+	}
 	// Data should be unchanged (no injection into <2 bytes)
 	if data[0] != 1 {
 		t.Errorf("expected data[0]=1, got %d", data[0])

--- a/internal/dns/server/cache_test.go
+++ b/internal/dns/server/cache_test.go
@@ -99,7 +99,7 @@ func TestCacheInvalidate(t *testing.T) {
 	}
 }
 
-func TestCacheGetReturnsCopyNotReference(t *testing.T) {
+func TestCacheGetReturnsInternalSlice(t *testing.T) {
 	done := make(chan struct{})
 	t.Cleanup(func() { close(done) })
 	cache := NewDNSCache(done, nil)
@@ -113,17 +113,22 @@ func TestCacheGetReturnsCopyNotReference(t *testing.T) {
 		t.Fatalf("Expected to find key %s", key)
 	}
 
-	// Mutate the returned slice
+	// Mutate the returned slice — this reflects the new zero-copy behavior
 	res[0] = 0xFF
 	res[1] = 0xFF
 
-	// Get again — internal data must be unchanged
+	// Get again — data should be mutated since Get() returns the internal slice
 	res2, found := cache.Get(key)
 	if !found {
 		t.Fatalf("Expected to find key %s on second call", key)
 	}
-	if res2[0] != 1 || res2[1] != 2 {
-		t.Errorf("Internal cache data was mutated — Get() returned a reference, not a copy")
+	if res2[0] != 0xFF || res2[1] != 0xFF {
+		t.Errorf("Expected res2 to reflect mutation, got %v", res2)
+	}
+
+	// Verify the caller's original data was not affected (Set() made a copy)
+	if originalData[0] != 1 || originalData[1] != 2 {
+		t.Errorf("Caller's original data was mutated by Set()")
 	}
 }
 

--- a/internal/dns/server/cache_test.go
+++ b/internal/dns/server/cache_test.go
@@ -99,6 +99,45 @@ func TestCacheInvalidate(t *testing.T) {
 	}
 }
 
+func TestCacheGetInto(t *testing.T) {
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	cache := NewDNSCache(done, nil)
+	key := "getinto.com:1"
+
+	// Set 4-byte data
+	cache.Set(key, []byte{1, 2, 3, 4}, 1*time.Hour)
+
+	// GetInto with txID injection
+	data, found := cache.GetInto(key, 0x1234)
+	if !found {
+		t.Fatalf("expected to find key %s", key)
+	}
+	// Verify txID was injected
+	if data[0] != 0x12 || data[1] != 0x34 {
+		t.Errorf("expected txID injection 0x1234, got %x", []byte{data[0], data[1]})
+	}
+}
+
+func TestCacheGetIntoShortData(t *testing.T) {
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	cache := NewDNSCache(done, nil)
+	key := "short.com:1"
+
+	// Set 1-byte data (too short for txID injection)
+	cache.Set(key, []byte{1}, 1*time.Hour)
+
+	data, found := cache.GetInto(key, 0x1234)
+	if !found {
+		t.Fatalf("expected to find key %s", key)
+	}
+	// Data should be unchanged (no injection into <2 bytes)
+	if data[0] != 1 {
+		t.Errorf("expected data[0]=1, got %d", data[0])
+	}
+}
+
 func TestCacheGetReturnsInternalSlice(t *testing.T) {
 	done := make(chan struct{})
 	t.Cleanup(func() { close(done) })

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -494,8 +494,10 @@ func (s *Server) Run(ctx context.Context) error {
 						_ = c.SetReadDeadline(time.Now().Add(udpReadDeadline))
 						continue
 					}
-					data := buf[:n:n]
-					s.udpQueue <- udpTask{addr: addr, data: data, conn: c}
+					// Allocate fresh slice per packet to avoid aliasing with buf
+					packetData := make([]byte, n)
+					copy(packetData, buf[:n])
+					s.udpQueue <- udpTask{addr: addr, data: packetData, conn: c}
 				}
 			}
 		}(conn)

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -494,8 +494,7 @@ func (s *Server) Run(ctx context.Context) error {
 						_ = c.SetReadDeadline(time.Now().Add(udpReadDeadline))
 						continue
 					}
-					data := make([]byte, n)
-					copy(data, buf[:n])
+					data := buf[:n:n]
 					s.udpQueue <- udpTask{addr: addr, data: data, conn: c}
 				}
 			}


### PR DESCRIPTION
## Summary
- **UDP read loop**: use `buf[:n:n]` slice trick instead of `make([]byte, n)` + `copy()` — eliminates one heap allocation per UDP datagram
- **L1 cache Get()**: return `item.data` directly instead of allocating a new slice and copying — zero-copy on cache read
- **L1 cache Set()**: copy caller's data so the cache owns its backing array independently (callers can mutate safely after Set)
- Update `TestCacheGetReturnsCopyNotReference` → `TestCacheGetReturnsInternalSlice` to reflect new semantics

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test -short -timeout 5m ./...` all pass
- [x] `go test -race ./internal/dns/server/...` race detector clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached DNS responses are now protected from external mutation by copying inputs on store.

* **Refactor**
  * Read path avoids extra copying to improve memory efficiency; callers must not retain or mutate returned data.

* **Tests**
  * Expanded cache tests to verify read semantics, short-payload behavior, and injected-field handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/cloudDNS/pull/151)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->