### PR TITLE
fix: only disable SSL for localhost DATABASE_HOST overrides

### DIFF
--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -37,6 +37,29 @@ func main() {
 	}
 }
 
+// replaceSSLMode replaces sslmode values in DSN format string with the given mode.
+// Only matches space-delimited parameters to avoid matching sslmode within values.
+func replaceSSLMode(dbURL, mode string) string {
+	// Replace existing sslmode values (only as separate space-delimited params)
+	dbURL = replaceDSNParam(dbURL, "sslmode", mode)
+	if !strings.Contains(dbURL, "sslmode=") {
+		dbURL += " sslmode=" + mode
+	}
+	return dbURL
+}
+
+// replaceDSNParam replaces a parameter in DSN format (space-separated key=value pairs).
+// Only replaces exact param matches to avoid matching within values.
+func replaceDSNParam(dbURL, param, value string) string {
+	parts := strings.Fields(dbURL)
+	for i, p := range parts {
+		if strings.HasPrefix(p, param+"=") {
+			parts[i] = param + "=" + value
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
 // processDatabaseURL applies DATABASE_HOST overrides and SSL mode settings.
 // It handles both URL format (postgres://...) and DSN format (user=...).
 // Exported for testing.
@@ -49,9 +72,10 @@ func processDatabaseURL(dbURL, hostOverride string) string {
 		return dbURL
 	}
 
-	// Detect URL format vs DSN format by checking for ://
+	// Detect URL format vs DSN format by checking for postgres:// prefix
 	isURL := strings.HasPrefix(dbURL, "postgres://") || strings.HasPrefix(dbURL, "postgresql://")
 	if isURL {
+		// url.Parse won't fail on valid postgres:// URLs; safe to ignore error due to isURL guard
 		u, _ := url.Parse(dbURL)
 		u.Host = hostOverride
 		q := u.Query()
@@ -64,12 +88,7 @@ func processDatabaseURL(dbURL, hostOverride string) string {
 	// DSN format (user=... password=... host=... etc)
 	isLocalHost := hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1"
 	if isLocalHost {
-		dbURL = strings.ReplaceAll(dbURL, "sslmode=verify-full", "sslmode=disable")
-		dbURL = strings.ReplaceAll(dbURL, "sslmode=require", "sslmode=disable")
-		dbURL = strings.ReplaceAll(dbURL, "sslmode=prefer", "sslmode=disable")
-		if !strings.Contains(dbURL, "sslmode=") {
-			dbURL += " sslmode=disable"
-		}
+		dbURL = replaceSSLMode(dbURL, "disable")
 	}
 	if strings.Contains(dbURL, "host=") {
 		parts := strings.Split(dbURL, " ")

--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -37,6 +37,55 @@ func main() {
 	}
 }
 
+// processDatabaseURL applies DATABASE_HOST overrides and SSL mode settings.
+// It handles both URL format (postgres://...) and DSN format (user=...).
+// Exported for testing.
+func processDatabaseURL(dbURL, hostOverride string) string {
+	if dbURL == "" {
+		dbURL = "postgres://postgres:postgres@localhost:5432/clouddns?sslmode=disable"
+	}
+
+	if hostOverride == "" {
+		return dbURL
+	}
+
+	// Detect URL format vs DSN format by checking for ://
+	isURL := strings.HasPrefix(dbURL, "postgres://") || strings.HasPrefix(dbURL, "postgresql://")
+	if isURL {
+		u, _ := url.Parse(dbURL)
+		u.Host = hostOverride
+		q := u.Query()
+		if hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1" {
+			q.Set("sslmode", "disable")
+		}
+		u.RawQuery = q.Encode()
+		return u.String()
+	}
+	// DSN format (user=... password=... host=... etc)
+	isLocalHost := hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1"
+	if isLocalHost {
+		dbURL = strings.ReplaceAll(dbURL, "sslmode=verify-full", "sslmode=disable")
+		dbURL = strings.ReplaceAll(dbURL, "sslmode=require", "sslmode=disable")
+		dbURL = strings.ReplaceAll(dbURL, "sslmode=prefer", "sslmode=disable")
+		if !strings.Contains(dbURL, "sslmode=") {
+			dbURL += " sslmode=disable"
+		}
+	}
+	if strings.Contains(dbURL, "host=") {
+		parts := strings.Split(dbURL, " ")
+		for i, p := range parts {
+			if strings.HasPrefix(p, "host=") {
+				parts[i] = "host=" + hostOverride
+			}
+		}
+		dbURL = strings.Join(parts, " ")
+	} else {
+		dbURL += " host=" + hostOverride
+	}
+
+	return dbURL
+}
+
 // run is the main entry point for the cloudDNS daemon, initializing all components.
 func run(ctx context.Context) error {
 	runCtx, cancel := context.WithCancel(ctx)
@@ -77,50 +126,7 @@ func run(ctx context.Context) error {
 
 	slog.SetDefault(logger)
 
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		dbURL = "postgres://postgres:postgres@localhost:5432/clouddns?sslmode=disable"
-	}
-
-	// Allow overriding host for Cloud SQL Proxy sidecar
-	if hostOverride := os.Getenv("DATABASE_HOST"); hostOverride != "" && dbURL != "" && dbURL != "none" {
-		if u, err := url.Parse(dbURL); err == nil {
-			u.Host = hostOverride
-			// Only disable SSL for local proxy connections (Cloud SQL Proxy on localhost).
-			// Remote hosts should respect the user's SSL mode preference.
-			q := u.Query()
-			if hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1" {
-				q.Set("sslmode", "disable")
-			}
-			u.RawQuery = q.Encode()
-			dbURL = u.String()
-		} else if strings.Contains(dbURL, "=") {
-			// Handle DSN format (e.g., "user=... password=...")
-			// Only disable SSL for local connections to Cloud SQL Proxy
-			isLocalHost := hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1"
-			if isLocalHost {
-				dbURL = strings.ReplaceAll(dbURL, "sslmode=verify-full", "sslmode=disable")
-				dbURL = strings.ReplaceAll(dbURL, "sslmode=require", "sslmode=disable")
-				dbURL = strings.ReplaceAll(dbURL, "sslmode=prefer", "sslmode=disable")
-				if !strings.Contains(dbURL, "sslmode=") {
-					dbURL += " sslmode=disable"
-				}
-			}
-			// Host override in DSN
-			if strings.Contains(dbURL, "host=") {
-				// Very basic regex-like replacement for host
-				parts := strings.Split(dbURL, " ")
-				for i, p := range parts {
-					if strings.HasPrefix(p, "host=") {
-						parts[i] = "host=" + hostOverride
-					}
-				}
-				dbURL = strings.Join(parts, " ")
-			} else {
-				dbURL += " host=" + hostOverride
-			}
-		}
-	}
+	dbURL := processDatabaseURL(os.Getenv("DATABASE_URL"), os.Getenv("DATABASE_HOST"))
 
 	if dbURL != "none" {
 		parsedURL, err := url.Parse(dbURL)

--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -86,19 +86,25 @@ func run(ctx context.Context) error {
 	if hostOverride := os.Getenv("DATABASE_HOST"); hostOverride != "" && dbURL != "" && dbURL != "none" {
 		if u, err := url.Parse(dbURL); err == nil {
 			u.Host = hostOverride
-			// Force sslmode=disable for local proxy connections to avoid TLS handshake issues.
-			// Cloud SQL Proxy listening on 127.0.0.1 expects plain TCP from the application.
+			// Only disable SSL for local proxy connections (Cloud SQL Proxy on localhost).
+			// Remote hosts should respect the user's SSL mode preference.
 			q := u.Query()
-			q.Set("sslmode", "disable")
+			if hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1" {
+				q.Set("sslmode", "disable")
+			}
 			u.RawQuery = q.Encode()
 			dbURL = u.String()
 		} else if strings.Contains(dbURL, "=") {
 			// Handle DSN format (e.g., "user=... password=...")
-			dbURL = strings.ReplaceAll(dbURL, "sslmode=verify-full", "sslmode=disable")
-			dbURL = strings.ReplaceAll(dbURL, "sslmode=require", "sslmode=disable")
-			dbURL = strings.ReplaceAll(dbURL, "sslmode=prefer", "sslmode=disable")
-			if !strings.Contains(dbURL, "sslmode=") {
-				dbURL += " sslmode=disable"
+			// Only disable SSL for local connections to Cloud SQL Proxy
+			isLocalHost := hostOverride == "127.0.0.1" || hostOverride == "localhost" || hostOverride == "::1"
+			if isLocalHost {
+				dbURL = strings.ReplaceAll(dbURL, "sslmode=verify-full", "sslmode=disable")
+				dbURL = strings.ReplaceAll(dbURL, "sslmode=require", "sslmode=disable")
+				dbURL = strings.ReplaceAll(dbURL, "sslmode=prefer", "sslmode=disable")
+				if !strings.Contains(dbURL, "sslmode=") {
+					dbURL += " sslmode=disable"
+				}
 			}
 			// Host override in DSN
 			if strings.Contains(dbURL, "host=") {

--- a/cmd/clouddns/main_test.go
+++ b/cmd/clouddns/main_test.go
@@ -217,12 +217,33 @@ func TestRun_ConfigPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("DatabaseHostOverrideRemotePreservesSSL", func(t *testing.T) {
+		// Remote host should preserve user's sslmode (verify-full)
+		t.Setenv("DATABASE_URL", "postgres://user:pass@remote:5432/db?sslmode=verify-full")
+		t.Setenv("DATABASE_HOST", "db.example.com")
+		t.Setenv("API_ADDR", "test-exit")
+		// run() exits early due to test-exit, but sslmode must be preserved in the URL
+		if err := run(context.Background()); err != nil {
+			t.Errorf("run failed with remote host override: %v", err)
+		}
+	})
+
 	t.Run("DatabaseDSNOverride", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "user=foo password=bar host=remote port=5432 dbname=db sslmode=require")
 		t.Setenv("DATABASE_HOST", "127.0.0.1")
 		t.Setenv("API_ADDR", "test-exit")
 		if err := run(context.Background()); err != nil {
 			t.Errorf("run failed with DSN host override: %v", err)
+		}
+	})
+
+	t.Run("DatabaseDSNOverrideRemotePreservesSSL", func(t *testing.T) {
+		// Remote host should preserve user's sslmode (require)
+		t.Setenv("DATABASE_URL", "user=foo password=bar host=remote port=5432 dbname=db sslmode=require")
+		t.Setenv("DATABASE_HOST", "db.example.com")
+		t.Setenv("API_ADDR", "test-exit")
+		if err := run(context.Background()); err != nil {
+			t.Errorf("run failed with remote DSN host override: %v", err)
 		}
 	})
 

--- a/cmd/clouddns/main_test.go
+++ b/cmd/clouddns/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -339,4 +341,129 @@ func TestDatabasePoolConfigEnvVars(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProcessDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		dbURL        string
+		hostOverride string
+		wantSSLMode  string
+	}{
+		// URL format with localhost - should disable SSL
+		{
+			name:         "URL localhost disables SSL via 127.0.0.1",
+			dbURL:        "postgres://user:pass@remote:5432/db?sslmode=verify-full",
+			hostOverride: "127.0.0.1",
+			wantSSLMode:  "disable",
+		},
+		{
+			name:         "URL localhost disables SSL via localhost",
+			dbURL:        "postgres://user:pass@remote:5432/db?sslmode=require",
+			hostOverride: "localhost",
+			wantSSLMode:  "disable",
+		},
+		{
+			name:         "URL IPv6 localhost disables SSL",
+			dbURL:        "postgres://user:pass@remote:5432/db?sslmode=require",
+			hostOverride: "::1",
+			wantSSLMode:  "disable",
+		},
+		// URL format with remote host - should preserve SSL
+		{
+			name:         "URL remote host preserves SSL verify-full",
+			dbURL:        "postgres://user:pass@remote:5432/db?sslmode=verify-full",
+			hostOverride: "db.example.com",
+			wantSSLMode:  "verify-full",
+		},
+		{
+			name:         "URL remote host preserves SSL require",
+			dbURL:        "postgres://user:pass@remote:5432/db?sslmode=require",
+			hostOverride: "db.example.com",
+			wantSSLMode:  "require",
+		},
+		// No host override - preserve original
+		{
+			name:         "URL no override preserves original SSL",
+			dbURL:        "postgres://user:pass@remote:5432/db?sslmode=verify-full",
+			hostOverride: "",
+			wantSSLMode:  "verify-full",
+		},
+		// Default URL when empty
+		{
+			name:         "Empty URL uses default with disable",
+			dbURL:        "",
+			hostOverride: "127.0.0.1",
+			wantSSLMode:  "disable",
+		},
+		// DSN format - localhost disables SSL
+		{
+			name:         "DSN localhost disables SSL",
+			dbURL:        "user=foo password=bar host=remote port=5432 dbname=db sslmode=verify-full",
+			hostOverride: "127.0.0.1",
+			wantSSLMode:  "disable",
+		},
+		// DSN format - remote host preserves SSL
+		{
+			name:         "DSN remote host preserves SSL require",
+			dbURL:        "user=foo password=bar host=remote port=5432 dbname=db sslmode=require",
+			hostOverride: "db.example.com",
+			wantSSLMode:  "require",
+		},
+		// DSN format - no sslmode specified, localhost adds disable
+		{
+			name:         "DSN localhost adds sslmode disable when missing",
+			dbURL:        "user=foo password=bar host=remote port=5432 dbname=db",
+			hostOverride: "localhost",
+			wantSSLMode:  "disable",
+		},
+		// DSN format - remote host preserves SSL when sslmode missing
+		{
+			name:         "DSN remote host preserves no sslmode when missing",
+			dbURL:        "user=foo password=bar host=remote port=5432 dbname=db",
+			hostOverride: "db.example.com",
+			wantSSLMode:  "", // no sslmode set for remote
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := processDatabaseURL(tt.dbURL, tt.hostOverride)
+			got := extractSSLMode(result)
+			if got != tt.wantSSLMode {
+				t.Errorf("sslmode = %q, want %q", got, tt.wantSSLMode)
+			}
+		})
+	}
+}
+
+// extractSSLMode extracts sslmode from both URL format (?sslmode=) and DSN format (sslmode=).
+func extractSSLMode(s string) string {
+	// Try URL/scheme-relative format first
+	if strings.Contains(s, "://") || strings.HasPrefix(s, "//") {
+		if u, err := url.Parse(s); err == nil {
+			// Check query string first
+			if mode := u.Query().Get("sslmode"); mode != "" {
+				return mode
+			}
+			// For scheme-relative URLs (//host/path), sslmode may be in the path if it came from DSN
+			if strings.HasPrefix(s, "//") && u.Path != "" {
+				if idx := strings.Index(u.Path, "sslmode="); idx >= 0 {
+					rest := u.Path[idx+len("sslmode="):]
+					end := strings.IndexAny(rest, " ")
+					if end < 0 {
+						end = len(rest)
+					}
+					return rest[:end]
+				}
+			}
+		}
+	}
+	// DSN format: look for sslmode= in space-separated params
+	for _, part := range strings.Split(s, " ") {
+		if strings.HasPrefix(part, "sslmode=") {
+			return strings.TrimPrefix(part, "sslmode=")
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary
- When DATABASE_HOST is set to a localhost address (127.0.0.1, localhost, ::1), sslmode=disable is applied to avoid TLS handshake issues with Cloud SQL Proxy
- When DATABASE_HOST points to a remote host, the user's configured sslmode is preserved

## Test plan
- [x] `go build ./cmd/clouddns/...`
- [x] `go test -short -timeout 30s ./cmd/clouddns/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database connection SSL handling: SSL is now disabled only when connecting to local database hosts; existing SSL preferences are preserved for remote hosts.
* **Tests**
  * Added/updated tests to verify SSL-mode preservation when the database host is overridden to a remote host.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/cloudDNS/pull/152)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->