### PR TITLE
fix: use SOA MINIMUM for NXDOMAIN cache TTL per RFC 2308

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1315,10 +1315,11 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	}
 
 	// RFC 2308: For NXDOMAIN, use SOA MINIMUM field as TTL for negative caching
+	// Use min(MINIMUM, TTL) to cap negative cache TTL by SOA RR TTL; allow MINIMUM=0
 	if response.Header.ResCode == 3 {
 		for _, auth := range response.Authorities {
-			if auth.Type == packet.SOA && auth.Minimum > 0 {
-				ttl = auth.Minimum
+			if auth.Type == packet.SOA {
+				ttl = min(auth.Minimum, auth.TTL)
 				break
 			}
 		}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1314,6 +1314,16 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 		ttl = response.Authorities[0].TTL
 	}
 
+	// RFC 2308: For NXDOMAIN, use SOA MINIMUM field as TTL for negative caching
+	if response.Header.ResCode == 3 {
+		for _, auth := range response.Authorities {
+			if auth.Type == packet.SOA && auth.Minimum > 0 {
+				ttl = auth.Minimum
+				break
+			}
+		}
+	}
+
 	if (response.Header.ResCode == 0 || response.Header.ResCode == 3) && !response.Header.TruncatedMessage {
 		cacheData := make([]byte, len(resData))
 		copy(cacheData, resData)


### PR DESCRIPTION
## Summary
- RFC 2308: NXDOMAIN responses now use min(SOA.MINIMUM, SOA.TTL) for cache TTL instead of hardcoded 300s
- Properly respects MINIMUM=0 (meaning "do not cache") and caps TTL by SOA record TTL

## Test plan
- [x] `go build ./cmd/clouddns/...`
- [x] `go test -short -timeout 30s ./internal/dns/server/...`

Closes #114