### PR TITLE
perf: eliminate TCP double-copy and add SetNoCopy

### DIFF
--- a/internal/dns/server/cache.go
+++ b/internal/dns/server/cache.go
@@ -98,6 +98,20 @@ func (c *DNSCache) GetInto(key string, txID uint16) ([]byte, bool) {
 	return cached, true
 }
 
+// SetNoCopy stores data directly without copying. The caller must not
+// retain or mutate the passed slice after calling this method. Intended
+// for data that is already an independent heap copy (e.g., from Redis).
+func (c *DNSCache) SetNoCopy(key string, data []byte, ttl time.Duration) {
+	shard := c.getShard(key)
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+
+	shard.items[key] = cacheEntry{
+		data:      data,
+		expiresAt: time.Now().Add(ttl),
+	}
+}
+
 // Set stores a response in the cache with a specific TTL.
 // The input data is copied so the cache owns its own backing array.
 func (c *DNSCache) Set(key string, data []byte, ttl time.Duration) {

--- a/internal/dns/server/cache_test.go
+++ b/internal/dns/server/cache_test.go
@@ -187,6 +187,65 @@ func TestCacheGetReturnsInternalSlice(t *testing.T) {
 	}
 }
 
+func TestCacheSetNoCopy(t *testing.T) {
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	cache := NewDNSCache(done, nil)
+	key := "setnocopy.com:1"
+
+	// Set via SetNoCopy (no defensive copy)
+	originalData := []byte{1, 2, 3, 4}
+	cache.SetNoCopy(key, originalData, 1*time.Hour)
+
+	// Get should return the same backing array (not a copy)
+	res, found := cache.Get(key)
+	if !found {
+		t.Fatalf("expected to find key %s", key)
+	}
+	// Get returns internal slice — verify it's the same array
+	if &res[0] != &originalData[0] {
+		t.Errorf("expected Get to return same backing array as SetNoCopy input")
+	}
+
+	// GetInto should return a copy (TX ID injection) — not the internal
+	res2, found := cache.GetInto(key, 0xABCD)
+	if !found {
+		t.Fatalf("expected to find key %s via GetInto", key)
+	}
+	if res2[0] != 0xAB || res2[1] != 0xCD {
+		t.Errorf("expected txID 0xABCD, got %x", []byte{res2[0], res2[1]})
+	}
+	// Get's result should be unaffected by GetInto's copy (Get returns internal)
+	if res[0] != 1 || res[1] != 2 {
+		t.Errorf("Get result was mutated by GetInto")
+	}
+}
+
+func TestCacheSetNoCopyExpiration(t *testing.T) {
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	cache := NewDNSCache(done, nil)
+	key := "expire-nocopy.com:1"
+
+	// Set with very short TTL
+	cache.SetNoCopy(key, []byte{9, 8, 7}, 1*time.Millisecond)
+
+	// Should be found immediately
+	_, found := cache.Get(key)
+	if !found {
+		t.Fatalf("expected to find key %s before expiry", key)
+	}
+
+	// Wait for expiry
+	time.Sleep(10 * time.Millisecond)
+
+	// Should be gone
+	_, found = cache.Get(key)
+	if found {
+		t.Errorf("expected key %s to be expired", key)
+	}
+}
+
 func TestCachePing(t *testing.T) {
 	done := make(chan struct{})
 	t.Cleanup(func() { close(done) })

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -995,7 +995,7 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 			} else if remainingTTL > 60*time.Second {
 				remainingTTL = 60 * time.Second
 			}
-			s.Cache.Set(cacheKey, data, remainingTTL)
+			s.Cache.SetNoCopy(cacheKey, data, remainingTTL)
 			cachedData = data
 		} else if s.Redis != nil {
 			// Redis was checked but key not found = L2 miss


### PR DESCRIPTION
## Summary
- **TCP zero-copy**: Read TCP directly into pooled 64KB buffer (`reqBuffer.Buf`) instead of a temporary heap slice + `Load()` copy. Use stack-allocated `[2]byte` for length prefix.
- **SetNoCopy**: Add `SetNoCopy` method to DNSCache and use it for L2→L1 cache population (eliminates 1 copy on L2 hits).

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./internal/dns/server/...`
- [ ] CI pass