### PR TITLE
feat: add UpdateRecord endpoint to enable Writer role enforcement

### DIFF
--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -332,7 +332,9 @@ func (h *Handler) UpdateRecord(w http.ResponseWriter, r *http.Request) {
 	record.TenantID = tenantID
 
 	if err := h.svc.UpdateRecord(r.Context(), &record); err != nil {
-		h.writeJSONError(w, http.StatusInternalServerError, "An internal error occurred", err)
+		// Return 404 for both "not found" and "tenant mismatch" — prevents
+		// writers from probing whether record IDs exist under other tenants.
+		h.writeJSONError(w, http.StatusNotFound, "Record not found", nil)
 		return
 	}
 

--- a/internal/adapters/api/handler.go
+++ b/internal/adapters/api/handler.go
@@ -98,6 +98,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Write operations - rate limited per tenant
 	mux.Handle("POST /zones", cors(auth(rateLimitWrite(admin(http.HandlerFunc(h.CreateZone))))))
 	mux.Handle("POST /zones/{id}/records", cors(auth(rateLimitWrite(RequireRole(domain.RoleAdmin, domain.RoleWriter)(http.HandlerFunc(h.CreateRecord))))))
+	mux.Handle("PUT /zones/{zone_id}/records/{id}", cors(auth(rateLimitWrite(RequireRole(domain.RoleAdmin, domain.RoleWriter)(http.HandlerFunc(h.UpdateRecord))))))
 
 	// Delete operations - more restrictive
 	mux.Handle("DELETE /zones/{id}", cors(auth(rateLimitDeleteZone(admin(http.HandlerFunc(h.DeleteZone))))))
@@ -294,6 +295,49 @@ func (h *Handler) CreateRecord(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(record); err != nil {
+		h.logger.Error("failed to encode record response", "error", err)
+	}
+}
+
+// UpdateRecord handles PUT /zones/{zone_id}/records/{id} requests.
+func (h *Handler) UpdateRecord(w http.ResponseWriter, r *http.Request) {
+	zoneID := r.PathValue("zone_id")
+	id := r.PathValue("id")
+
+	var record domain.Record
+	if !validateContentType(r) {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBodySize)).Decode(&record); err != nil {
+		h.writeJSONError(w, http.StatusBadRequest, "Invalid request body", err)
+		return
+	}
+
+	if err := domain.ValidateRecord(&record); err != nil {
+		h.writeJSONError(w, http.StatusBadRequest, "Invalid record", err)
+		return
+	}
+
+	record.ID = id
+	record.ZoneID = zoneID
+
+	tenantID, ok := r.Context().Value(CtxTenantID).(string)
+	if !ok || tenantID == "" {
+		h.logger.Warn("UpdateRecord: missing or invalid tenant ID in context")
+		h.writeJSONError(w, http.StatusUnauthorized, "Unauthorized: missing tenant context", nil)
+		return
+	}
+	record.TenantID = tenantID
+
+	if err := h.svc.UpdateRecord(r.Context(), &record); err != nil {
+		h.writeJSONError(w, http.StatusInternalServerError, "An internal error occurred", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(w).Encode(record); err != nil {
 		h.logger.Error("failed to encode record response", "error", err)
 	}

--- a/internal/adapters/api/handler_test.go
+++ b/internal/adapters/api/handler_test.go
@@ -469,6 +469,60 @@ func TestCreateRecordValidation(t *testing.T) {
 	}
 }
 
+func TestUpdateRecordSuccess(t *testing.T) {
+	svc := &mockDNSService{}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	rec := domain.Record{Name: "www.test.com.", Type: domain.TypeA, Content: "5.6.7.8", TTL: 300}
+	body, _ := json.Marshal(rec)
+	req := httptest.NewRequest("PUT", "/zones/z1/records/r1", bytes.NewBuffer(body))
+	req = withTenant(req, testTenantID)
+	w := httptest.NewRecorder()
+
+	handler.UpdateRecord(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", w.Code)
+	}
+}
+
+func TestUpdateRecordNotFound(t *testing.T) {
+	svc := &mockDNSService{err: errors.New("not found")}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	rec := domain.Record{Name: "www.test.com.", Type: domain.TypeA, Content: "5.6.7.8", TTL: 300}
+	body, _ := json.Marshal(rec)
+	req := httptest.NewRequest("PUT", "/zones/z1/records/r1", bytes.NewBuffer(body))
+	req = withTenant(req, testTenantID)
+	w := httptest.NewRecorder()
+
+	handler.UpdateRecord(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", w.Code)
+	}
+}
+
+func TestUpdateRecordMissingTenant(t *testing.T) {
+	svc := &mockDNSService{}
+	repo := &testutil.MockRepo{}
+	handler := New(svc, repo, slog.Default())
+
+	rec := domain.Record{Name: "www.test.com.", Type: domain.TypeA, Content: "5.6.7.8", TTL: 300}
+	body, _ := json.Marshal(rec)
+	req := httptest.NewRequest("PUT", "/zones/z1/records/r1", bytes.NewBuffer(body))
+	// No withTenant call — missing tenant context
+	w := httptest.NewRecorder()
+
+	handler.UpdateRecord(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Expected status 401, got %d", w.Code)
+	}
+}
+
 func TestDeleteZoneSuccess(t *testing.T) {
 	svc := &mockDNSService{}
 	repo := &testutil.MockRepo{}

--- a/internal/adapters/api/handler_test.go
+++ b/internal/adapters/api/handler_test.go
@@ -100,6 +100,14 @@ func (m *mockDNSService) UpdateRecordHealth(_ context.Context, _ string, _ domai
 	return m.err
 }
 
+func (m *mockDNSService) UpdateRecord(_ context.Context, record *domain.Record) error {
+	if m.err != nil {
+		return m.err
+	}
+	record.ID = "rec-updated"
+	return nil
+}
+
 func (m *mockDNSService) HealthCheck(_ context.Context) map[string]error {
 	res := make(map[string]error)
 	res["postgres"] = m.err

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -589,8 +589,8 @@ func (r *PostgresRepository) CreateRecord(ctx context.Context, record *domain.Re
 
 // UpdateRecord implements ports.DNSRepository.
 func (r *PostgresRepository) UpdateRecord(ctx context.Context, record *domain.Record) error {
-	query := `UPDATE dns_records SET name = $1, type = $2, content = $3, ttl = $4, priority = $5, weight = $6, port = $7, network = $8, health_check_type = $9, health_check_target = $10, updated_at = $11 WHERE id = $12`
-	_, err := r.db.ExecContext(ctx, query, record.Name, record.Type, record.Content, record.TTL, record.Priority, record.Weight, record.Port, record.Network, record.HealthCheckType, record.HealthCheckTarget, record.UpdatedAt, record.ID)
+	query := `UPDATE dns_records SET name = $1, type = $2, content = $3, ttl = $4, priority = $5, weight = $6, port = $7, network = $8, health_check_type = $9, health_check_target = $10, updated_at = $11 WHERE id = $12 AND tenant_id = $13`
+	_, err := r.db.ExecContext(ctx, query, record.Name, record.Type, record.Content, record.TTL, record.Priority, record.Weight, record.Port, record.Network, record.HealthCheckType, record.HealthCheckTarget, record.UpdatedAt, record.ID, record.TenantID)
 	return err
 }
 

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -587,6 +587,13 @@ func (r *PostgresRepository) CreateRecord(ctx context.Context, record *domain.Re
 	return err
 }
 
+// UpdateRecord implements ports.DNSRepository.
+func (r *PostgresRepository) UpdateRecord(ctx context.Context, record *domain.Record) error {
+	query := `UPDATE dns_records SET name = $1, type = $2, content = $3, ttl = $4, priority = $5, weight = $6, port = $7, network = $8, health_check_type = $9, health_check_target = $10, updated_at = $11 WHERE id = $12`
+	_, err := r.db.ExecContext(ctx, query, record.Name, record.Type, record.Content, record.TTL, record.Priority, record.Weight, record.Port, record.Network, record.HealthCheckType, record.HealthCheckTarget, record.UpdatedAt, record.ID)
+	return err
+}
+
 // UpdateRecordHealth implements ports.DNSRepository.
 func (r *PostgresRepository) UpdateRecordHealth(ctx context.Context, recordID string, status domain.HealthStatus, errMsg string) error {
 	query := `

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -589,9 +589,8 @@ func (r *PostgresRepository) CreateRecord(ctx context.Context, record *domain.Re
 
 // UpdateRecord implements ports.DNSRepository.
 func (r *PostgresRepository) UpdateRecord(ctx context.Context, record *domain.Record) error {
-	query := `UPDATE dns_records SET name = $1, type = $2, content = $3, ttl = $4, priority = $5, weight = $6, port = $7, network = $8, health_check_type = $9, health_check_target = $10, updated_at = $11 WHERE id = $12 AND tenant_id = $13`
-	_, err := r.db.ExecContext(ctx, query, record.Name, record.Type, record.Content, record.TTL, record.Priority, record.Weight, record.Port, record.Network, record.HealthCheckType, record.HealthCheckTarget, record.UpdatedAt, record.ID, record.TenantID)
-	return err
+	query := `UPDATE dns_records SET name = $1, type = $2, content = $3, ttl = $4, priority = $5, weight = $6, port = $7, network = $8, health_check_type = $9, health_check_target = $10, updated_at = $11 WHERE id = $12 AND tenant_id = $13 RETURNING updated_at`
+	return r.db.QueryRowContext(ctx, query, record.Name, record.Type, record.Content, record.TTL, record.Priority, record.Weight, record.Port, record.Network, record.HealthCheckType, record.HealthCheckTarget, record.UpdatedAt, record.ID, record.TenantID).Scan(&record.UpdatedAt)
 }
 
 // UpdateRecordHealth implements ports.DNSRepository.

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -30,6 +30,7 @@ type DNSRepository interface {
 	CreateZoneWithRecords(ctx context.Context, zone *domain.Zone, records []domain.Record) error
 	CreateRecord(ctx context.Context, record *domain.Record) error
 	BatchCreateRecords(ctx context.Context, records []domain.Record) error
+	UpdateRecord(ctx context.Context, record *domain.Record) error
 	ListZones(ctx context.Context, tenantID string) ([]domain.Zone, error)
 	DeleteZone(ctx context.Context, zoneID string, tenantID string) error
 	DeleteRecord(ctx context.Context, recordID string, zoneID string, tenantID string) error
@@ -72,6 +73,7 @@ type DNSService interface {
 	Resolve(ctx context.Context, name string, qType domain.RecordType, clientIP string) ([]domain.Record, error)
 	GetRecordsToProbeStreaming(ctx context.Context) (RecordIterator, error) // Added for Smart Engine
 	UpdateRecordHealth(ctx context.Context, recordID string, status domain.HealthStatus, errMsg string) error // Added for Smart Engine
+	UpdateRecord(ctx context.Context, record *domain.Record) error
 	ListZones(ctx context.Context, tenantID string) ([]domain.Zone, error)
 	ListRecordsForZone(ctx context.Context, zoneID string, tenantID string) ([]domain.Record, error)
 	DeleteZone(ctx context.Context, zoneID string, tenantID string) error

--- a/internal/core/services/anycast_manager_test.go
+++ b/internal/core/services/anycast_manager_test.go
@@ -62,6 +62,10 @@ func (m *mockAnycastDNSService) UpdateRecordHealth(_ context.Context, _ string, 
 	return nil
 }
 
+func (m *mockAnycastDNSService) UpdateRecord(_ context.Context, record *domain.Record) error {
+	return nil
+}
+
 func TestAnycastManager_Lifecycle(t *testing.T) {
 	dnsSvc := &mockAnycastDNSService{healthy: true}
 	routing := &testutil.MockRoutingEngine{}
@@ -160,6 +164,10 @@ func (m *mockMultiBackendService) GetRecordsToProbeStreaming(_ context.Context) 
 }
 
 func (m *mockMultiBackendService) UpdateRecordHealth(_ context.Context, _ string, _ domain.HealthStatus, _ string) error {
+	return nil
+}
+
+func (m *mockMultiBackendService) UpdateRecord(_ context.Context, record *domain.Record) error {
 	return nil
 }
 

--- a/internal/core/services/audit_test.go
+++ b/internal/core/services/audit_test.go
@@ -87,6 +87,10 @@ func (m *auditMockRepo) UpdateRecordHealth(ctx context.Context, recordID string,
 	return m.mockRepo.UpdateRecordHealth(ctx, recordID, status, errMsg)
 }
 
+func (m *auditMockRepo) UpdateRecord(ctx context.Context, record *domain.Record) error {
+	return m.mockRepo.UpdateRecord(ctx, record)
+}
+
 func (m *auditMockRepo) DeleteRecord(ctx context.Context, recordID string, zoneID string, tenantID string) error {
 	return m.mockRepo.DeleteRecord(ctx, recordID, zoneID, tenantID)
 }

--- a/internal/core/services/dns_service.go
+++ b/internal/core/services/dns_service.go
@@ -99,7 +99,7 @@ func (s *dnsService) CreateRecord(ctx context.Context, record *domain.Record) er
 		}
 	}
 
-	s.audit(ctx, "unknown", "CREATE_RECORD", "RECORD", record.ID, fmt.Sprintf("Created %s record for %s", record.Type, record.Name))
+	s.audit(ctx, record.TenantID, "CREATE_RECORD", "RECORD", record.ID, fmt.Sprintf("Created %s record for %s", record.Type, record.Name))
 	return nil
 }
 
@@ -122,7 +122,7 @@ func (s *dnsService) UpdateRecord(ctx context.Context, record *domain.Record) er
 		}
 	}
 
-	s.audit(ctx, "unknown", "UPDATE_RECORD", "RECORD", record.ID, fmt.Sprintf("Updated %s record for %s", record.Type, record.Name))
+	s.audit(ctx, record.TenantID, "UPDATE_RECORD", "RECORD", record.ID, fmt.Sprintf("Updated %s record for %s", record.Type, record.Name))
 	return nil
 }
 

--- a/internal/core/services/dns_service.go
+++ b/internal/core/services/dns_service.go
@@ -103,6 +103,29 @@ func (s *dnsService) CreateRecord(ctx context.Context, record *domain.Record) er
 	return nil
 }
 
+// UpdateRecord updates an existing DNS record.
+func (s *dnsService) UpdateRecord(ctx context.Context, record *domain.Record) error {
+	record.UpdatedAt = time.Now()
+
+	if record.TTL < 60 {
+		record.TTL = 60
+	}
+
+	if err := s.repo.UpdateRecord(ctx, record); err != nil {
+		return err
+	}
+
+	// Invalidate cache across all nodes
+	if s.cache != nil {
+		if err := s.cache.Invalidate(ctx, record.Name, record.Type); err != nil {
+			s.logger.Warn("failed to invalidate cache after record update", "name", record.Name, "type", record.Type, "error", err)
+		}
+	}
+
+	s.audit(ctx, "unknown", "UPDATE_RECORD", "RECORD", record.ID, fmt.Sprintf("Updated %s record for %s", record.Type, record.Name))
+	return nil
+}
+
 // audit logs an action to the audit trail via the repository.
 func (s *dnsService) audit(ctx context.Context, tenantID, action, resType, resID, details string) {
 	logEntry := &domain.AuditLog{

--- a/internal/core/services/dns_service_test.go
+++ b/internal/core/services/dns_service_test.go
@@ -287,6 +287,10 @@ func (m *mockRepo) UpdateRecordHealth(_ context.Context, _ string, _ domain.Heal
 	return m.err
 }
 
+func (m *mockRepo) UpdateRecord(_ context.Context, record *domain.Record) error {
+	return m.err
+}
+
 func TestDNSService_ExtraMethods(t *testing.T) {
 	repo := &mockRepo{}
 	svc := NewDNSService(repo, nil)

--- a/internal/core/services/dnssec_service_test.go
+++ b/internal/core/services/dnssec_service_test.go
@@ -83,6 +83,10 @@ func (m *mockDNSSECRepo) UpdateRecordHealth(_ context.Context, _ string, _ domai
 	return nil
 }
 
+func (m *mockDNSSECRepo) UpdateRecord(_ context.Context, record *domain.Record) error {
+	return nil
+}
+
 func (m *mockDNSSECRepo) GetRecordsToProbeStreaming(_ context.Context) (ports.RecordIterator, error) {
 	return nil, nil
 }

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -291,6 +291,10 @@ func (m *mockServerRepo) UpdateRecordHealth(ctx context.Context, recordID string
 	return nil
 }
 
+func (m *mockServerRepo) UpdateRecord(ctx context.Context, record *domain.Record) error {
+	return nil
+}
+
 func (m *mockServerRepo) GetRecordsToProbe(ctx context.Context) ([]domain.Record, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/testutil/mock_repo.go
+++ b/internal/testutil/mock_repo.go
@@ -102,6 +102,12 @@ func (m *MockRepo) BatchCreateRecords(_ context.Context, records []domain.Record
 	return args.Error(0)
 }
 
+// UpdateRecord implements ports.DNSRepository for testing.
+func (m *MockRepo) UpdateRecord(_ context.Context, record *domain.Record) error {
+	args := m.Called(record)
+	return args.Error(0)
+}
+
 // ListZones implements ports.DNSRepository for testing.
 func (m *MockRepo) ListZones(_ context.Context, tenantID string) ([]domain.Zone, error) {
 	args := m.Called(tenantID)
@@ -317,6 +323,12 @@ func (m *MockDNSService) DeleteZone(_ context.Context, zoneID string, tenantID s
 // DeleteRecord implements ports.DNSService for testing.
 func (m *MockDNSService) DeleteRecord(_ context.Context, recordID string, zoneID string, tenantID string) error {
 	args := m.Called(recordID, zoneID, tenantID)
+	return args.Error(0)
+}
+
+// UpdateRecord implements ports.DNSService for testing.
+func (m *MockDNSService) UpdateRecord(_ context.Context, record *domain.Record) error {
+	args := m.Called(record)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
## Summary
- Issue #85: Writer role existed in schema but had no functional enforcement
- Added `PUT /zones/{zone_id}/records/{id}` endpoint for updating records
- Writers can now UPDATE records (CREATE/UPDATE) per documented role permissions
- `RequireRole(domain.RoleAdmin, domain.RoleWriter)` middleware already enforced access - this adds the missing endpoint

## Changes
- `ports.go`: Added `UpdateRecord` to `DNSRepository` and `DNSService` interfaces
- `dns_service.go`: Added `UpdateRecord` method with cache invalidation and proper tenantID audit
- `postgres.go`: Added `UpdateRecord` SQL with tenant isolation in WHERE clause + RETURNING for accurate timestamps
- `handler.go`: Added `UpdateRecord` handler and route

## Security
- `WHERE id = $12 AND tenant_id = $13` prevents cross-tenant record updates

## Test plan
- [x] `go build ./cmd/clouddns/...`
- [x] `go test -short -timeout 60s ./...`

Closes #85