### PR TITLE
fix: standardize all logging on log/slog (issue #79)

### DIFF
--- a/cmd/iana-bench/main.go
+++ b/cmd/iana-bench/main.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/big"
 	"net"
 	"os"
@@ -22,7 +22,8 @@ import (
 
 func main() {
 	if err := Run(os.Args); err != nil {
-		log.Fatalf("iana-bench failed: %v", err)
+		slog.Error("iana-bench failed", "error", err)
+		os.Exit(1)
 	}
 }
 
@@ -50,7 +51,7 @@ func Run(args []string) error {
 	}
 	defer func() {
 		if errClose := db.Close(); errClose != nil {
-			log.Printf("failed to close database: %v", errClose)
+			slog.Error("failed to close database", "error", errClose)
 		}
 	}()
 
@@ -65,7 +66,7 @@ func RunBench(db *sql.DB, target string, count, concurrency int) error {
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			slog.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -103,7 +104,7 @@ func RunBench(db *sql.DB, target string, count, concurrency int) error {
 			}
 			defer func() {
 				if errClose := conn.Close(); errClose != nil {
-					log.Printf("failed to close connection: %v", errClose)
+					slog.Error("failed to close connection", "error", errClose)
 				}
 			}()
 

--- a/cmd/iana-import/main.go
+++ b/cmd/iana-import/main.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -24,7 +24,8 @@ const rootZoneURL = "https://www.internic.net/domain/root.zone"
 
 func main() {
 	if err := Run(os.Args); err != nil {
-		log.Fatalf("iana-import failed: %v", err)
+		slog.Error("iana-import failed", "error", err)
+		os.Exit(1)
 	}
 }
 
@@ -40,7 +41,7 @@ func Run([]string) error {
 	}
 	defer func() {
 		if errClose := db.Close(); errClose != nil {
-			log.Printf("failed to close database: %v", errClose)
+			slog.Error("failed to close database", "error", errClose)
 		}
 	}()
 
@@ -61,7 +62,7 @@ func RunImport(ctx context.Context, repo ports.DNSRepository, url string) error 
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
-			log.Printf("failed to close response body: %v", errClose)
+			slog.Error("failed to close response body", "error", errClose)
 		}
 	}()
 

--- a/cmd/top1m-import/main.go
+++ b/cmd/top1m-import/main.go
@@ -9,7 +9,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -31,50 +31,50 @@ func main() {
 
 	db, err := sql.Open("pgx", dbURL)
 	if err != nil {
-		log.Fatalf("failed to connect to database: %v", err)
+		slog.Error("failed to connect to database", "error", err); os.Exit(1)
 	}
 	defer func() {
 		if errClose := db.Close(); errClose != nil {
-			log.Printf("failed to close database: %v", errClose)
+			slog.Error("failed to close database", "error", errClose)
 		}
 	}()
 
 	fmt.Printf("Downloading Top 1M list from %s...\n", top1mURL)
 	resp, err := http.Get(top1mURL)
 	if err != nil {
-		log.Fatalf("failed to download: %v", err)
+		slog.Error("failed to download", "error", err); os.Exit(1)
 	}
 	defer func() {
 		if errClose := resp.Body.Close(); errClose != nil {
-			log.Printf("failed to close response body: %v", errClose)
+			slog.Error("failed to close response body", "error", errClose)
 		}
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Fatalf("bad status: %s", resp.Status)
+		slog.Error("bad status", "status", resp.Status); os.Exit(1)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("failed to read body: %v", err)
+		slog.Error("failed to read body", "error", err); os.Exit(1)
 	}
 
 	zr, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
 	if err != nil {
-		log.Fatalf("failed to open zip: %v", err)
+		slog.Error("failed to open zip", "error", err); os.Exit(1)
 	}
 
 	if len(zr.File) == 0 {
-		log.Fatal("zip file is empty")
+		slog.Error("zip file is empty"); os.Exit(1)
 	}
 
 	f, err := zr.File[0].Open()
 	if err != nil {
-		log.Fatalf("failed to open csv in zip: %v", err)
+		slog.Error("failed to open csv in zip", "error", err); os.Exit(1)
 	}
 	defer func() {
 		if errClose := f.Close(); errClose != nil {
-			log.Printf("failed to close file in zip: %v", errClose)
+			slog.Error("failed to close file in zip", "error", errClose)
 		}
 	}()
 
@@ -86,7 +86,7 @@ func main() {
 	zoneName := "top1m.test."
 	zone, err := repo.GetZone(ctx, zoneName)
 	if err != nil {
-		log.Fatalf("failed to check zone: %v", err)
+		slog.Error("failed to check zone", "error", err); os.Exit(1)
 	}
 
 	var zoneID string
@@ -96,7 +96,7 @@ func main() {
 			ID: zoneID, TenantID: "bench", Name: zoneName,
 		})
 		if err != nil {
-			log.Fatalf("failed to create zone: %v", err)
+			slog.Error("failed to create zone", "error", err); os.Exit(1)
 		}
 	} else {
 		zoneID = zone.ID
@@ -139,7 +139,7 @@ func main() {
 
 		if len(records) >= batchSize {
 			if err := repo.BatchCreateRecords(ctx, records); err != nil {
-				log.Fatalf("batch insert failed: %v", err)
+				slog.Error("batch insert failed", "error", err); os.Exit(1)
 			}
 			total += len(records)
 			fmt.Printf("Imported %d records...\n", total)
@@ -149,7 +149,7 @@ func main() {
 
 	if len(records) > 0 {
 		if err := repo.BatchCreateRecords(ctx, records); err != nil {
-			log.Fatalf("final batch insert failed: %v", err)
+			slog.Error("final batch insert failed", "error", err); os.Exit(1)
 		}
 		total += len(records)
 	}

--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net"
 	"regexp"
@@ -24,12 +24,13 @@ import (
 
 // PostgresRepository implements ports.DNSRepository using PostgreSQL.
 type PostgresRepository struct {
-	db *sql.DB
+	db     *sql.DB
+	logger *slog.Logger
 }
 
 // NewPostgresRepository creates and returns a new PostgresRepository instance.
 func NewPostgresRepository(db *sql.DB) *PostgresRepository {
-	return &PostgresRepository{db: db}
+	return &PostgresRepository{db: db, logger: slog.New(slog.NewTextHandler(nil, nil))}
 }
 
 // GetRecords implements ports.DNSRepository.
@@ -60,7 +61,7 @@ func (r *PostgresRepository) GetRecords(ctx context.Context, name string, qType 
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -137,7 +138,7 @@ func (r *PostgresRepository) GetRecordsByNames(ctx context.Context, names []stri
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -193,7 +194,7 @@ func (r *PostgresRepository) GetIPsForName(ctx context.Context, name string, cli
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -284,7 +285,7 @@ func (r *PostgresRepository) GetDNSKEYs(ctx context.Context, zoneName string) ([
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -379,7 +380,7 @@ func (r *PostgresRepository) ListRecordsForZone(ctx context.Context, zoneID stri
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -531,7 +532,7 @@ func (r *PostgresRepository) CreateZoneWithRecords(ctx context.Context, zone *do
 	}
 	defer func() {
 		if errRollback := tx.Rollback(); errRollback != nil && !errors.Is(errRollback, sql.ErrTxDone) {
-			log.Printf("failed to rollback transaction: %v", errRollback)
+			r.logger.Error("failed to rollback transaction", "error", errRollback)
 		}
 	}()
 
@@ -629,7 +630,7 @@ func (r *PostgresRepository) BatchCreateRecords(ctx context.Context, records []d
 	}
 	defer func() {
 		if errRollback := tx.Rollback(); errRollback != nil && !errors.Is(errRollback, sql.ErrTxDone) {
-			log.Printf("failed to rollback batch transaction: %v", errRollback)
+			r.logger.Error("failed to rollback batch transaction", "error", errRollback)
 		}
 	}()
 
@@ -711,7 +712,7 @@ func (r *PostgresRepository) ListZones(ctx context.Context, tenantID string) ([]
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -813,7 +814,7 @@ func (r *PostgresRepository) ListZoneChanges(ctx context.Context, zoneID string,
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -931,7 +932,7 @@ func (r *PostgresRepository) GetAuditLogs(ctx context.Context, tenantID string) 
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -961,7 +962,7 @@ func (r *PostgresRepository) ApplyZoneUpdate(ctx context.Context, zoneID string,
 	}
 	defer func() {
 		if errRollback := tx.Rollback(); errRollback != nil && !errors.Is(errRollback, sql.ErrTxDone) {
-			log.Printf("failed to rollback transaction: %v", errRollback)
+			r.logger.Error("failed to rollback transaction", "error", errRollback)
 		}
 	}()
 
@@ -984,7 +985,7 @@ func (r *PostgresRepository) ApplyZoneUpdate(ctx context.Context, zoneID string,
 	newSerial := currentSerial + 1
 	// Detect uint32 wraparound (Go doesn't panic on overflow, it wraps silently)
 	if newSerial == 0 && currentSerial != 0 {
-		log.Printf("SOA serial overflow, resetting to 0 for zone %s", zoneID)
+		r.logger.Warn("SOA serial overflow, resetting to 0", "zone_id", zoneID)
 	}
 
 	for _, op := range operations {
@@ -1054,7 +1055,7 @@ func (r *PostgresRepository) ListKeysForZone(ctx context.Context, zoneID string)
 	}
 	defer func() {
 		if errClose := rows.Close(); errClose != nil {
-			log.Printf("failed to close rows: %v", errClose)
+			r.logger.Error("failed to close rows", "error", errClose)
 		}
 	}()
 
@@ -1115,7 +1116,7 @@ func (r *PostgresRepository) ListAPIKeys(ctx context.Context, tenantID string) (
 	}
 	defer func() {
 		if cerr := rows.Close(); cerr != nil {
-			log.Printf("failed to close rows: %v", cerr)
+			r.logger.Error("failed to close rows", "error", cerr)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- Issue #79: Standardize all logging on `log/slog` across the codebase
- Replaced legacy `log` package with structured `log/slog` in 4 files

## Changes
- `internal/adapters/repository/postgres.go`: Added `*slog.Logger` field to `PostgresRepository`, replaced 12 `log.Printf` calls with `slog.Error`/`slog.Warn`
- `cmd/iana-bench/main.go`: Replaced `log.Fatalf`/`log.Printf` with `slog` + `os.Exit(1)`
- `cmd/iana-import/main.go`: Replaced `log.Fatalf`/`log.Printf` with `slog` + `os.Exit(1)`
- `cmd/top1m-import/main.go`: Replaced `log.Fatalf`/`log.Printf`/`log.Fatal` with `slog` + `os.Exit(1)`

## Verification
- `go build ./cmd/...` — all entry points compile
- `go test -short -timeout 60s ./...` — no regressions
- `grep -r '"log"' cmd/ internal/adapters/repository/` — no results (no legacy log imports)

Closes #79