### PR TITLE
perf: eliminate TCP double-copy and add SetNoCopy

### DIFF
--- a/internal/dns/packet/buffer.go
+++ b/internal/dns/packet/buffer.go
@@ -9,6 +9,7 @@ import (
 
 // BytePacketBuffer simplifies reading and writing the DNS packet buffer.
 type BytePacketBuffer struct {
+	mu       sync.Mutex
 	Buf      []byte
 	Pos      int
 	Len      int            // High-water mark of data loaded or written
@@ -33,17 +34,26 @@ var bufferPool = sync.Pool{
 // GetBuffer retrieves a buffer from the pool.
 func GetBuffer() *BytePacketBuffer {
 	b := bufferPool.Get().(*BytePacketBuffer)
-	b.Reset()
+	if b != nil {
+		b.Reset()
+	}
 	return b
 }
 
 // PutBuffer returns a buffer to the pool.
 func PutBuffer(b *BytePacketBuffer) {
-	bufferPool.Put(b)
+	if b != nil {
+		bufferPool.Put(b)
+	}
 }
 
 // Reset clears the buffer state for reuse.
 func (b *BytePacketBuffer) Reset() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.Pos = 0
 	b.Len = 0
 	b.parsing = false

--- a/internal/dns/server/edge_test.go
+++ b/internal/dns/server/edge_test.go
@@ -66,7 +66,7 @@ func TestHandleIXFR_NoAuthority(t *testing.T) {
 	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "test.", QType: packet.IXFR})
 	
 	// No Authority section
-	srv.handleIXFR(context.Background(), &mockConn{}, req, nil)
+	srv.handleIXFR(context.Background(), &mockConn{}, req, nil, nil)
 }
 
 type mockConn struct {

--- a/internal/dns/server/rfc1035_test.go
+++ b/internal/dns/server/rfc1035_test.go
@@ -178,7 +178,7 @@ func TestRFC1035_AXFR(t *testing.T) {
 	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "axfr.test.", QType: packet.AXFR})
 	
 	// Handle AXFR in background
-	go srv.handleAXFR(context.Background(), serverConn, req, nil)
+	go srv.handleAXFR(context.Background(), serverConn, req, nil, nil)
 
 	// Read stream: RFC 1035 requires SOA first and SOA last
 	// We expect: SOA, NS, A, SOA (4 packets)
@@ -226,7 +226,7 @@ func TestHandleAXFR_ErrorPaths(t *testing.T) {
 	req.Header.ID = 1
 	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "missing.zone.", QType: packet.AXFR})
 	
-	srv.handleAXFR(context.Background(), conn, req, nil)
+	srv.handleAXFR(context.Background(), conn, req, nil, nil)
 	if len(conn.captured) != 1 {
 		t.Errorf("Expected NXDOMAIN response")
 	}
@@ -235,7 +235,7 @@ func TestHandleAXFR_ErrorPaths(t *testing.T) {
 	repo.zones = append(repo.zones, domain.Zone{ID: "z1", Name: "nosoa.zone."})
 	req.Questions[0].Name = "nosoa.zone."
 	conn.captured = nil
-	srv.handleAXFR(context.Background(), conn, req, nil)
+	srv.handleAXFR(context.Background(), conn, req, nil, nil)
 	if len(conn.captured) != 1 {
 		t.Errorf("Expected SERVFAIL response")
 	}

--- a/internal/dns/server/rfc1995_test.go
+++ b/internal/dns/server/rfc1995_test.go
@@ -35,7 +35,7 @@ func TestHandleIXFR_UpToDate(t *testing.T) {
 
 	// IXFR requires TCP
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, nil)
+	srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 	// Verify response: should just be the SOA
 	if len(conn.captured) != 1 {
@@ -81,7 +81,7 @@ func TestHandleIXFR_WithChanges(t *testing.T) {
 	})
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, nil)
+	srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 	// Sequence: [Current SOA] -> [Old SOA, Deletions] -> [New SOA, Additions] -> [Current SOA]
 	// Our stub implementation sends multiple responses
@@ -113,7 +113,7 @@ func TestHandleIXFR_MissingSOA(t *testing.T) {
 	})
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, nil)
+	srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("expected exactly 1 TCP response for missing SOA IXFR, got %d", len(conn.captured))
@@ -139,7 +139,7 @@ func TestHandleIXFR_NoAuthoritySOA(t *testing.T) {
 	// Missing SOA in Authority Section
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, nil)
+	srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("expected exactly 1 TCP response for malformed IXFR (no authority SOA), got %d", len(conn.captured))
@@ -165,7 +165,7 @@ func TestHandleIXFR_ZoneNotFound(t *testing.T) {
 	})
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, nil)
+	srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("expected exactly 1 TCP response for unknown zone IXFR, got %d", len(conn.captured))
@@ -206,7 +206,7 @@ func TestHandleIXFR_InvalidSOA(t *testing.T) {
 			})
 
 			conn := &mockTCPConn{}
-			srv.handleIXFR(context.Background(), conn, req, nil)
+			srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 			if len(conn.captured) != 1 {
 				t.Fatalf("Expected exactly 1 SERVFAIL response for invalid SOA, got %d", len(conn.captured))
@@ -246,7 +246,7 @@ func TestHandleIXFR_GapInHistoryFallback(t *testing.T) {
 	})
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, nil)
+	srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 	// Should fallback to AXFR. AXFR sequence: SOA, then all records, then SOA.
 	// records: SOA, www.gap.test., new.gap.test.
@@ -324,7 +324,7 @@ func TestHandleIXFR_ListRecordsErrors(t *testing.T) {
 			})
 
 			conn := &mockTCPConn{}
-			srv.handleIXFR(context.Background(), conn, req, nil)
+			srv.handleIXFR(context.Background(), conn, req, nil, nil)
 
 			if len(conn.captured) != 1 {
 				t.Fatalf("Expected exactly 1 SERVFAIL response for list records failure, got %d", len(conn.captured))

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -687,35 +687,34 @@ func (s *Server) handleUDPConnection(ctx context.Context, pc net.PacketConn, add
 func (s *Server) handleTCPConnection(ctx context.Context, conn net.Conn) {
 	defer func() { _ = conn.Close() }()
 	for {
-		lenBuf := make([]byte, 2)
-		if _, errRead := io.ReadFull(conn, lenBuf); errRead != nil {
+		lenBuf := [2]byte{}
+		if _, errRead := io.ReadFull(conn, lenBuf[:]); errRead != nil {
 			return
 		}
 		packetLen := uint16(lenBuf[0])<<8 | uint16(lenBuf[1])
-		data := make([]byte, packetLen)
-		if _, errRead := io.ReadFull(conn, data); errRead != nil {
+		reqBuffer := packet.GetBuffer()
+		if _, errRead := io.ReadFull(conn, reqBuffer.Buf[:packetLen]); errRead != nil {
+			packet.PutBuffer(reqBuffer)
 			return
 		}
+		reqBuffer.Load(reqBuffer.Buf[:packetLen]) // initializes Pos, Len, parsing, names — copy is a no-op since data is already in Buf
 
-		// Check for AXFR/IXFR
-		reqBuffer := packet.GetBuffer()
-		reqBuffer.Load(data)
 		request := packet.NewDNSPacket()
 		if errFromBuf := request.FromBuffer(reqBuffer); errFromBuf == nil && len(request.Questions) > 0 {
 			if request.Questions[0].QType == packet.AXFR {
-				s.handleAXFR(ctx, conn, request, data)
+				s.handleAXFR(ctx, conn, request, reqBuffer.Buf[:packetLen])
 				packet.PutBuffer(reqBuffer)
 				continue
 			}
 			if request.Questions[0].QType == packet.IXFR {
-				s.handleIXFR(ctx, conn, request, data)
+				s.handleIXFR(ctx, conn, request, reqBuffer.Buf[:packetLen])
 				packet.PutBuffer(reqBuffer)
 				continue
 			}
 		}
 		packet.PutBuffer(reqBuffer)
 
-		if errHandle := s.handlePacket(ctx, data, conn.RemoteAddr(), func(resp []byte) error {
+		if errHandle := s.handlePacket(ctx, reqBuffer.Buf[:packetLen], conn.RemoteAddr(), func(resp []byte) error {
 			resLen := uint16(len(resp)) // #nosec G115
 			fullResp := append([]byte{byte(resLen >> 8), byte(resLen & 0xFF)}, resp...)
 			_, errWrite := conn.Write(fullResp)

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -702,13 +702,11 @@ func (s *Server) handleTCPConnection(ctx context.Context, conn net.Conn) {
 		request := packet.NewDNSPacket()
 		if errFromBuf := request.FromBuffer(reqBuffer); errFromBuf == nil && len(request.Questions) > 0 {
 			if request.Questions[0].QType == packet.AXFR {
-				s.handleAXFR(ctx, conn, request, reqBuffer.Buf[:packetLen])
-				packet.PutBuffer(reqBuffer)
+				s.handleAXFR(ctx, conn, request, reqBuffer.Buf[:packetLen], reqBuffer)
 				continue
 			}
 			if request.Questions[0].QType == packet.IXFR {
-				s.handleIXFR(ctx, conn, request, reqBuffer.Buf[:packetLen])
-				packet.PutBuffer(reqBuffer)
+				s.handleIXFR(ctx, conn, request, reqBuffer.Buf[:packetLen], reqBuffer)
 				continue
 			}
 		}
@@ -726,7 +724,8 @@ func (s *Server) handleTCPConnection(ctx context.Context, conn net.Conn) {
 }
 
 // handleAXFR processes a DNS zone transfer (AXFR) request over TCP.
-func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.DNSPacket, rawData []byte) {
+func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.DNSPacket, rawData []byte, buffer *packet.BytePacketBuffer) {
+	defer packet.PutBuffer(buffer)
 	q := request.Questions[0]
 	if !strings.HasSuffix(q.Name, ".") {
 		q.Name += "."
@@ -1496,7 +1495,8 @@ func (s *Server) handleUpdate(ctx context.Context, request *packet.DNSPacket, ra
 }
 
 // handleIXFR processes an incremental zone transfer (IXFR) request over TCP.
-func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.DNSPacket, rawData []byte) {
+func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.DNSPacket, rawData []byte, buffer *packet.BytePacketBuffer) {
+	defer packet.PutBuffer(buffer)
 	q := request.Questions[0]
 	if !strings.HasSuffix(q.Name, ".") {
 		q.Name += "."

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -1103,7 +1103,7 @@ func TestHandleAXFR_ConvertError(t *testing.T) {
 	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "axfr-fail.test.", QType: packet.AXFR})
 
 	conn := &mockTCPConn{}
-	srv.handleAXFR(context.Background(), conn, req, nil)
+	srv.handleAXFR(context.Background(), conn, req, nil, nil)
 
 	if len(conn.captured) < 2 {
 		t.Errorf("Expected at least 2 records (Start SOA and End SOA)")
@@ -1171,7 +1171,7 @@ func TestHandleAXFR_NoSOA(t *testing.T) {
 	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "nosoa.test.", QType: packet.AXFR})
 
 	conn := &mockTCPConn{}
-	srv.handleAXFR(context.Background(), conn, req, nil)
+	srv.handleAXFR(context.Background(), conn, req, nil, nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 error packet, got %d", len(conn.captured))
@@ -1200,7 +1200,7 @@ func TestHandleAXFR_StreamingError(t *testing.T) {
 	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "stream-fail.test.", QType: packet.AXFR})
 
 	conn := &mockTCPConn{}
-	srv.handleAXFR(context.Background(), conn, req, nil)
+	srv.handleAXFR(context.Background(), conn, req, nil, nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 error packet, got %d", len(conn.captured))
@@ -1236,7 +1236,7 @@ func TestHandleAXFR_TSIGUnknownKey(t *testing.T) {
 	_ = req.SignTSIG(buf, "unknown-key.", []byte("any"))
 
 	conn := &mockTCPConn{}
-	srv.handleAXFR(context.Background(), conn, req, buf.Buf[:buf.Position()])
+	srv.handleAXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
@@ -1276,7 +1276,7 @@ func TestHandleAXFR_TSIGVerifyFailed(t *testing.T) {
 	buf.Buf[0] ^= 0xFF
 
 	conn := &mockTCPConn{}
-	srv.handleAXFR(context.Background(), conn, req, buf.Buf[:buf.Position()])
+	srv.handleAXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
@@ -1353,7 +1353,7 @@ func TestHandleIXFR_TSIGUnknownKey(t *testing.T) {
 	_ = req.SignTSIG(buf, "unknown-key.", []byte("any"))
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()])
+	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
@@ -1398,7 +1398,7 @@ func TestHandleIXFR_TSIGVerifyFailed(t *testing.T) {
 	buf.Buf[0] ^= 0xFF
 
 	conn := &mockTCPConn{}
-	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()])
+	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 response, got %d", len(conn.captured))


### PR DESCRIPTION
## Summary
- **TCP zero-copy**: Read TCP directly into pooled 64KB buffer instead of temp heap slice + second copy via `Load()`. Use stack-allocated `[2]byte` for length prefix.
- **SetNoCopy**: Add `SetNoCopy` method to DNSCache and use it for L2→L1 cache population.

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./internal/dns/server/...`
- [ ] CI pass