### PR TITLE
fix: default CORS to empty origins (issue #159)

### DIFF
--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -56,13 +56,11 @@ type CORSConfig struct {
 	MaxAge         int
 }
 
-// DefaultCORSConfig creates config from CORS_ALLOWED_ORIGINS env var (comma-separated, or "*" for all).
+// DefaultCORSConfig creates config from CORS_ALLOWED_ORIGINS env var (comma-separated).
+// When the env var is not set, no origins are allowed — operators must explicitly configure.
 func DefaultCORSConfig() *CORSConfig {
 	origins := os.Getenv("CORS_ALLOWED_ORIGINS")
-	if origins == "" {
-		origins = "*"
-	}
-	// Parse and trim each origin, ignoring empty strings
+	// No default — empty means no origins allowed (secure by default)
 	rawOrigins := strings.Split(origins, ",")
 	allowed := make([]string, 0, len(rawOrigins))
 	for _, o := range rawOrigins {

--- a/internal/adapters/api/middleware_test.go
+++ b/internal/adapters/api/middleware_test.go
@@ -417,15 +417,22 @@ func TestCORSMiddleware(t *testing.T) {
 }
 
 func TestDefaultCORSConfig(t *testing.T) {
-	t.Run("DefaultWildcard", func(t *testing.T) {
-		// This test relies on CORS_ALLOWED_ORIGINS not being set
+	t.Run("DefaultEmptyOrigins", func(t *testing.T) {
+		// When CORS_ALLOWED_ORIGINS is not set, no origins are allowed (secure default)
 		t.Setenv("CORS_ALLOWED_ORIGINS", "")
 		config := DefaultCORSConfig()
-		if len(config.AllowedOrigins) != 1 || config.AllowedOrigins[0] != "*" {
-			t.Errorf("expected [*], got %v", config.AllowedOrigins)
+		if len(config.AllowedOrigins) != 0 {
+			t.Errorf("expected empty AllowedOrigins, got %v", config.AllowedOrigins)
 		}
 		if config.MaxAge != 86400 {
 			t.Errorf("expected 86400, got %d", config.MaxAge)
+		}
+		// Verify no origin is allowed
+		if config.isOriginAllowed("https://localhost") {
+			t.Errorf("expected localhost to NOT be allowed with empty config")
+		}
+		if config.isOriginAllowed("*") {
+			t.Errorf("expected * to NOT be allowed with empty config")
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Issue #159: Insecure default CORS (`*` when env var not set)
- Remove the `*` default when `CORS_ALLOWED_ORIGINS` is unset — now no origins are allowed by default
- Operators must explicitly configure allowed origins

## Changes
- `middleware.go`: Removed `if origins == "" { origins = "*" }` fallback
- `middleware_test.go`: Renamed `DefaultWildcard` → `DefaultEmptyOrigins`, added assertions for empty origins and `isOriginAllowed` returning false for all inputs

## Test plan
- [x] `go build ./cmd/clouddns/...`
- [x] `go test -short -timeout 60s ./internal/adapters/api/...`

Closes #159