### PR TITLE
fix: propagate ignored errors in handleAXFR and GenerateKey (issue #161)

### DIFF
--- a/internal/core/services/dnssec_service.go
+++ b/internal/core/services/dnssec_service.go
@@ -37,8 +37,14 @@ func (s *DNSSECService) GenerateKey(ctx context.Context, zoneID string, keyType 
 		return nil, fmt.Errorf("failed to generate key: %w", err)
 	}
 
-	privBytes, _ := x509.MarshalECPrivateKey(priv)
-	pubBytes, _ := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	privBytes, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ECDSA private key: %w", err)
+	}
+	pubBytes, err := x509.MarshalPKIXPublicKey(&priv.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ECDSA public key: %w", err)
+	}
 
 	key := &domain.DNSSECKey{
 		ID:         uuid.New().String(),

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -749,7 +749,12 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 		}
 	}
 
-	zone, _ := s.Repo.GetZone(ctx, q.Name)
+	zone, err := s.Repo.GetZone(ctx, q.Name)
+	if err != nil {
+		s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
+		s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
+		return
+	}
 	if zone == nil {
 		s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
 		s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN


### PR DESCRIPTION
## Summary
- Issue #161: Ignored errors in zone lookup and DNSSEC marshaling
- `handleAXFR`: Check `GetZone` error → return SERVFAIL instead of treating DB failures as NXDOMAIN
- `GenerateKey`: Check `x509.MarshalECPrivateKey`/`MarshalPKIXPublicKey` errors → return instead of storing keys with nil bytes

## Changes
- `internal/dns/server/server.go`: handleAXFR now checks `GetZone` error, logs and returns SERVFAIL
- `internal/core/services/dnssec_service.go`: GenerateKey now returns marshaling errors

## Test plan
- [x] `go build ./cmd/clouddns/...`
- [x] `go test -short -timeout 60s ./internal/dns/server/... ./internal/core/services/...`

Closes #161