### PR TITLE
Make Redis pool settings configurable via environment variables

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -338,7 +338,7 @@ func runScaleTest(count int, concurrency int) {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	repo := repository.NewPostgresRepository(db)
 	srv := server.NewServer(addr, repo, logger)
-	srv.Redis = server.NewRedisCache(redisURL, "", 0)
+	srv.Redis = server.NewRedisCache(redisURL, "", 0, server.RedisPoolConfig{})
 	
 	srvCtx, cancelSrv := context.WithCancel(ctx)
 	defer cancelSrv()

--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -230,7 +230,33 @@ func run(ctx context.Context) error {
 	redisURL := os.Getenv("REDIS_URL")
 	var redisCache *server.RedisCache
 	if redisURL != "" {
-		redisCache = server.NewRedisCache(redisURL, "", 0)
+		redisPoolCfg := server.RedisPoolConfig{
+			PoolSize:        100,
+			MinIdleConns:    0,
+			PoolTimeout:     5 * time.Minute,
+			ConnMaxLifetime: 0,
+		}
+		if v := os.Getenv("REDIS_POOL_SIZE"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				redisPoolCfg.PoolSize = n
+			}
+		}
+		if v := os.Getenv("REDIS_MIN_IDLE_CONNS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				redisPoolCfg.MinIdleConns = n
+			}
+		}
+		if v := os.Getenv("REDIS_IDLE_TIMEOUT_MINUTES"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				redisPoolCfg.PoolTimeout = time.Duration(n) * time.Minute
+			}
+		}
+		if v := os.Getenv("REDIS_CONN_MAX_LIFETIME_MINUTES"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n > 0 {
+				redisPoolCfg.ConnMaxLifetime = time.Duration(n) * time.Minute
+			}
+		}
+		redisCache = server.NewRedisCache(redisURL, "", 0, redisPoolCfg)
 		// Verify connectivity
 		pingCtx, cancel := context.WithTimeout(runCtx, 2*time.Second)
 		if err := redisCache.Ping(pingCtx); err != nil {

--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -239,21 +239,29 @@ func run(ctx context.Context) error {
 		if v := os.Getenv("REDIS_POOL_SIZE"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				redisPoolCfg.PoolSize = n
+			} else {
+				logger.Warn("invalid REDIS_POOL_SIZE, keeping default", "value", v, "reason", "must be a positive integer")
 			}
 		}
 		if v := os.Getenv("REDIS_MIN_IDLE_CONNS"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 				redisPoolCfg.MinIdleConns = n
+			} else {
+				logger.Warn("invalid REDIS_MIN_IDLE_CONNS, keeping default", "value", v, "reason", "must be a non-negative integer")
 			}
 		}
 		if v := os.Getenv("REDIS_POOL_TIMEOUT_MINUTES"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				redisPoolCfg.PoolTimeout = time.Duration(n) * time.Minute
+			} else {
+				logger.Warn("invalid REDIS_POOL_TIMEOUT_MINUTES, keeping default", "value", v, "reason", "must be a positive integer")
 			}
 		}
 		if v := os.Getenv("REDIS_CONN_MAX_LIFETIME_MINUTES"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				redisPoolCfg.ConnMaxLifetime = time.Duration(n) * time.Minute
+			} else {
+				logger.Warn("invalid REDIS_CONN_MAX_LIFETIME_MINUTES, keeping default", "value", v, "reason", "must be a positive integer")
 			}
 		}
 		redisCache = server.NewRedisCache(redisURL, "", 0, redisPoolCfg)

--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -246,7 +246,7 @@ func run(ctx context.Context) error {
 				redisPoolCfg.MinIdleConns = n
 			}
 		}
-		if v := os.Getenv("REDIS_IDLE_TIMEOUT_MINUTES"); v != "" {
+		if v := os.Getenv("REDIS_POOL_TIMEOUT_MINUTES"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil && n > 0 {
 				redisPoolCfg.PoolTimeout = time.Duration(n) * time.Minute
 			}

--- a/internal/dns/server/cache_hammer_test.go
+++ b/internal/dns/server/cache_hammer_test.go
@@ -26,7 +26,7 @@ func TestCache_ConcurrencyHammer(t *testing.T) {
 
 	// Setup Server with Redis
 	srv := NewServer("127.0.0.1:0", nil, nil)
-	srv.Redis = NewRedisCache(mr.Addr(), "", 0)
+	srv.Redis = NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 
 	// Run for 3 seconds
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)

--- a/internal/dns/server/cache_integration_test.go
+++ b/internal/dns/server/cache_integration_test.go
@@ -22,7 +22,7 @@ func TestCacheInvalidation_Integration(t *testing.T) {
 
 	// 2. Setup Server with Redis
 	srv := NewServer("127.0.0.1:0", nil, nil)
-	srv.Redis = NewRedisCache(mr.Addr(), "", 0)
+	srv.Redis = NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -60,7 +60,7 @@ func TestCacheInvalidation_MalformedPayload(t *testing.T) {
 	defer mr.Close()
 
 	srv := NewServer("127.0.0.1:0", nil, nil)
-	srv.Redis = NewRedisCache(mr.Addr(), "", 0)
+	srv.Redis = NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/dns/server/redis.go
+++ b/internal/dns/server/redis.go
@@ -130,6 +130,17 @@ func (r *RedisCache) DLQLen(ctx context.Context) (int64, error) {
 	return r.client.LLen(ctx, DLQChannel).Result()
 }
 
+// PoolConfig returns the pool configuration currently applied to the client.
+func (r *RedisCache) PoolConfig() RedisPoolConfig {
+	opts := r.client.Options()
+	return RedisPoolConfig{
+		PoolSize:       opts.PoolSize,
+		MinIdleConns:   opts.MinIdleConns,
+		PoolTimeout:    opts.PoolTimeout,
+		ConnMaxLifetime: opts.ConnMaxLifetime,
+	}
+}
+
 // Close shuts down the Redis client connection.
 func (r *RedisCache) Close() error {
 	return r.client.Close()

--- a/internal/dns/server/redis.go
+++ b/internal/dns/server/redis.go
@@ -22,12 +22,24 @@ type RedisCache struct {
 	client *redis.Client
 }
 
+// RedisPoolConfig holds connection pool settings for the Redis client.
+type RedisPoolConfig struct {
+	PoolSize       int
+	MinIdleConns   int
+	PoolTimeout    time.Duration
+	ConnMaxLifetime time.Duration
+}
+
 // NewRedisCache creates a new Redis cache client.
-func NewRedisCache(addr string, password string, db int) *RedisCache {
+func NewRedisCache(addr string, password string, db int, cfg RedisPoolConfig) *RedisCache {
 	rdb := redis.NewClient(&redis.Options{
-		Addr:     addr,
-		Password: password,
-		DB:       db,
+		Addr:            addr,
+		Password:        password,
+		DB:              db,
+		PoolSize:        cfg.PoolSize,
+		MinIdleConns:    cfg.MinIdleConns,
+		PoolTimeout:     cfg.PoolTimeout,
+		ConnMaxLifetime: cfg.ConnMaxLifetime,
 	})
 	return &RedisCache{client: rdb}
 }

--- a/internal/dns/server/redis_test.go
+++ b/internal/dns/server/redis_test.go
@@ -158,3 +158,24 @@ func TestRedisCache_Close(t *testing.T) {
 		t.Errorf("Expected Ping to fail after Close")
 	}
 }
+
+func TestRedisCache_PoolConfig(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("Failed to run miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	cfg := RedisPoolConfig{
+		PoolSize:       50,
+		MinIdleConns:   5,
+		PoolTimeout:    30 * time.Second,
+		ConnMaxLifetime: 10 * time.Minute,
+	}
+	cache := NewRedisCache(mr.Addr(), "", 0, cfg)
+	defer cache.Close()
+
+	if err := cache.Ping(context.Background()); err != nil {
+		t.Errorf("Ping failed with pool config: %v", err)
+	}
+}

--- a/internal/dns/server/redis_test.go
+++ b/internal/dns/server/redis_test.go
@@ -17,7 +17,7 @@ func TestRedisCache(t *testing.T) {
 	defer mr.Close()
 
 	// 2. Initialize RedisCache
-	cache := NewRedisCache(mr.Addr(), "", 0)
+	cache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	ctx := context.Background()
 
 	// 3. Test Set and Get
@@ -49,7 +49,7 @@ func TestRedisCache_GetWithTTL(t *testing.T) {
 	}
 	defer mr.Close()
 
-	cache := NewRedisCache(mr.Addr(), "", 0)
+	cache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	ctx := context.Background()
 
 	key := "get-with-ttl.test."
@@ -78,7 +78,7 @@ func TestRedisCache_GetWithTTL(t *testing.T) {
 func TestRedisCache_Ping(t *testing.T) {
 	mr, _ := miniredis.Run()
 	defer mr.Close()
-	cache := NewRedisCache(mr.Addr(), "", 0)
+	cache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	if err := cache.Ping(context.Background()); err != nil {
 		t.Errorf("Ping failed: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestRedisCache_Ping(t *testing.T) {
 func TestRedisCache_Subscribe(t *testing.T) {
 	mr, _ := miniredis.Run()
 	defer mr.Close()
-	cache := NewRedisCache(mr.Addr(), "", 0)
+	cache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	ch := cache.Subscribe(context.Background())
 	if ch == nil {
 		t.Error("Subscribe returned nil channel")
@@ -101,7 +101,7 @@ func TestRedisCache_PopFromDLQ(t *testing.T) {
 	}
 	defer mr.Close()
 
-	rdb := NewRedisCache(mr.Addr(), "", 0)
+	rdb := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	ctx := context.Background()
 
 	// Test timeout case
@@ -125,7 +125,7 @@ func TestRedisCache_DLQLen(t *testing.T) {
 	}
 	defer mr.Close()
 
-	rdb := NewRedisCache(mr.Addr(), "", 0)
+	rdb := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	ctx := context.Background()
 
 	// Empty DLQ
@@ -149,7 +149,7 @@ func TestRedisCache_Close(t *testing.T) {
 		t.Fatalf("Failed to run miniredis: %v", err)
 	}
 	// Don't defer mr.Close() — Close should handle it
-	cache := NewRedisCache(mr.Addr(), "", 0)
+	cache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	if err := cache.Close(); err != nil {
 		t.Errorf("Close failed: %v", err)
 	}

--- a/internal/dns/server/redis_test.go
+++ b/internal/dns/server/redis_test.go
@@ -178,4 +178,18 @@ func TestRedisCache_PoolConfig(t *testing.T) {
 	if err := cache.Ping(context.Background()); err != nil {
 		t.Errorf("Ping failed with pool config: %v", err)
 	}
+
+	got := cache.PoolConfig()
+	if got.PoolSize != cfg.PoolSize {
+		t.Errorf("PoolSize = %d, want %d", got.PoolSize, cfg.PoolSize)
+	}
+	if got.MinIdleConns != cfg.MinIdleConns {
+		t.Errorf("MinIdleConns = %d, want %d", got.MinIdleConns, cfg.MinIdleConns)
+	}
+	if got.PoolTimeout != cfg.PoolTimeout {
+		t.Errorf("PoolTimeout = %v, want %v", got.PoolTimeout, cfg.PoolTimeout)
+	}
+	if got.ConnMaxLifetime != cfg.ConnMaxLifetime {
+		t.Errorf("ConnMaxLifetime = %v, want %v", got.ConnMaxLifetime, cfg.ConnMaxLifetime)
+	}
 }

--- a/internal/dns/server/server_internal_test.go
+++ b/internal/dns/server/server_internal_test.go
@@ -184,7 +184,7 @@ func TestGetWithTTLReturnsCorrectValue(t *testing.T) {
 	}
 	defer mr.Close()
 
-	cache := NewRedisCache(mr.Addr(), "", 0)
+	cache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	ctx := context.Background()
 
 	// Set a key with known TTL

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -1424,7 +1424,7 @@ func TestDLQRetryWorker_Shutdown(t *testing.T) {
 	}
 	defer mr.Close()
 
-	redisCache := NewRedisCache(mr.Addr(), "", 0)
+	redisCache := NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
 	defer redisCache.Close()
 
 	srv := &Server{


### PR DESCRIPTION
## Summary
- Add `RedisPoolConfig` struct with `PoolSize`, `MinIdleConns`, `PoolTimeout`, `ConnMaxLifetime` fields
- Update `NewRedisCache` signature to accept `RedisPoolConfig` parameter
- Add environment variables: `REDIS_POOL_SIZE` (default 100), `REDIS_MIN_IDLE_CONNS` (default 0), `REDIS_POOL_TIMEOUT_MINUTES` (default 5), `REDIS_CONN_MAX_LIFETIME_MINUTES` (default 0)
- Add test for pool config construction and ping
- Update all call sites in tests and bench to pass `RedisPoolConfig{}`

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redis connection pool is now configurable via environment variables (`REDIS_POOL_SIZE`, `REDIS_MIN_IDLE_CONNS`, `REDIS_POOL_TIMEOUT_MINUTES`, `REDIS_CONN_MAX_LIFETIME_MINUTES`), allowing operators to optimize pooling behavior for their deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/cloudDNS/pull/170)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->