### PR TITLE
perf: eliminate per-byte mutex overhead in DNSRecord.Write

### DIFF
--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -728,9 +728,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		for _, opt := range r.Options {
 			if err := buffer.Writeu16(opt.Code); err != nil { return 0, err }
 			if err := buffer.Writeu16(uint16(len(opt.Data))); err != nil { return 0, err } // #nosec G115
-			for _, b := range opt.Data { 
-				if err := buffer.Write(b); err != nil { return 0, err }
-			}
+			if err := buffer.WriteRange(buffer.Position(), opt.Data); err != nil { return 0, err }
 		}
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
@@ -751,15 +749,11 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Writeu32(uint32(r.TimeSigned & 0xFFFFFFFF)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Writeu16(r.Fudge); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(len(r.MAC))); err != nil { return 0, err } // #nosec G115
-		for _, b := range r.MAC { 
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.MAC); err != nil { return 0, err }
 		if err := buffer.Writeu16(r.OriginalID); err != nil { return 0, err }
 		if err := buffer.Writeu16(r.Error); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(len(r.Other))); err != nil { return 0, err } // #nosec G115
-		for _, b := range r.Other { 
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.Other); err != nil { return 0, err }
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
@@ -787,15 +781,10 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 	switch r.Type {
 	case A:
 		if err := buffer.Writeu16(4); err != nil { return 0, err }
-		ip4 := r.IP.To4()
-		for _, b := range ip4 { 
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.IP.To4()); err != nil { return 0, err }
 	case AAAA:
 		if err := buffer.Writeu16(16); err != nil { return 0, err }
-		for _, b := range r.IP.To16() { 
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.IP.To16()); err != nil { return 0, err }
 	case NS, CNAME, PTR, MD, MF, MB, MG, MR:
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }
@@ -827,9 +816,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 	case TXT:
 		if err := buffer.Writeu16(uint16(len(r.Txt) + 1)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Write(byte(len(r.Txt))); err != nil { return 0, err } // #nosec G115
-		for i := 0; i < len(r.Txt); i++ {
-			if err := buffer.Write(r.Txt[i]); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), []byte(r.Txt)); err != nil { return 0, err }
 	case SOA:
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }
@@ -847,13 +834,9 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 	case HINFO:
 		if err := buffer.Writeu16(uint16(len(r.CPU) + len(r.OS) + 2)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Write(byte(len(r.CPU))); err != nil { return 0, err } // #nosec G115
-		for i := 0; i < len(r.CPU); i++ {
-			if err := buffer.Write(r.CPU[i]); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), []byte(r.CPU)); err != nil { return 0, err }
 		if err := buffer.Write(byte(len(r.OS))); err != nil { return 0, err } // #nosec G115
-		for i := 0; i < len(r.OS); i++ {
-			if err := buffer.Write(r.OS[i]); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), []byte(r.OS)); err != nil { return 0, err }
 	case MINFO:
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }
@@ -867,9 +850,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }
 		if err := buffer.WriteName(r.NextName); err != nil { return 0, err }
-		for _, b := range r.TypeBitMap {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.TypeBitMap); err != nil { return 0, err }
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
@@ -879,9 +860,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Writeu16(r.Flags); err != nil { return 0, err }
 		if err := buffer.Write(3); err != nil { return 0, err } // Protocol
 		if err := buffer.Write(r.Algorithm); err != nil { return 0, err }
-		for _, b := range r.PublicKey {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.PublicKey); err != nil { return 0, err }
 	case RRSIG:
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }
@@ -893,9 +872,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Writeu32(r.Inception); err != nil { return 0, err }
 		if err := buffer.Writeu16(r.KeyTag); err != nil { return 0, err }
 		if err := buffer.WriteName(r.SignerName); err != nil { return 0, err }
-		for _, b := range r.Signature {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.Signature); err != nil { return 0, err }
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
@@ -907,16 +884,10 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Write(uint8(r.Flags)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Writeu16(r.Iterations); err != nil { return 0, err }
 		if err := buffer.Write(uint8(len(r.Salt))); err != nil { return 0, err } // #nosec G115
-		for _, b := range r.Salt {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.Salt); err != nil { return 0, err }
 		if err := buffer.Write(uint8(len(r.NextHash))); err != nil { return 0, err } // #nosec G115
-		for _, b := range r.NextHash {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
-		for _, b := range r.TypeBitMap {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.NextHash); err != nil { return 0, err }
+		if err := buffer.WriteRange(buffer.Position(), r.TypeBitMap); err != nil { return 0, err }
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
@@ -928,9 +899,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Write(uint8(r.Flags)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Writeu16(r.Iterations); err != nil { return 0, err }
 		if err := buffer.Write(uint8(len(r.Salt))); err != nil { return 0, err } // #nosec G115
-		for _, b := range r.Salt {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.Salt); err != nil { return 0, err }
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
@@ -940,9 +909,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Writeu16(r.KeyTag); err != nil { return 0, err }
 		if err := buffer.Write(r.Algorithm); err != nil { return 0, err }
 		if err := buffer.Write(r.DigestType); err != nil { return 0, err }
-		for _, b := range r.Digest {
-			if err := buffer.Write(b); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), r.Digest); err != nil { return 0, err }
 	case CAA:
 		if len(r.CAATag) > 255 {
 			return 0, fmt.Errorf("CAA tag too long: %d", len(r.CAATag))
@@ -951,12 +918,8 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if err := buffer.Writeu16(0); err != nil { return 0, err } // Placeholder for RDLENGTH
 		if err := buffer.Write(r.CAAFlag); err != nil { return 0, err }
 		if err := buffer.Write(uint8(len(r.CAATag))); err != nil { return 0, err } // #nosec G115
-		for i := 0; i < len(r.CAATag); i++ {
-			if err := buffer.Write(r.CAATag[i]); err != nil { return 0, err }
-		}
-		for i := 0; i < len(r.CAAValue); i++ {
-			if err := buffer.Write(r.CAAValue[i]); err != nil { return 0, err }
-		}
+		if err := buffer.WriteRange(buffer.Position(), []byte(r.CAATag)); err != nil { return 0, err }
+		if err := buffer.WriteRange(buffer.Position(), []byte(r.CAAValue)); err != nil { return 0, err }
 		currPos := buffer.Position()
 		if err := buffer.Seek(lenPos); err != nil { return 0, err }
 		if err := buffer.Writeu16(uint16(currPos - (lenPos + 2))); err != nil { return 0, err } // #nosec G115
@@ -982,9 +945,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 			if err := buffer.Write(1); err != nil { return 0, err }
 			alpnValue := strings.Join(r.HTTPSAlpn, ",")
 			if err := buffer.Writeu16(uint16(len(alpnValue))); err != nil { return 0, err }
-			for i := 0; i < len(alpnValue); i++ {
-				if err := buffer.Write(alpnValue[i]); err != nil { return 0, err }
-			}
+			if err := buffer.WriteRange(buffer.Position(), []byte(alpnValue)); err != nil { return 0, err }
 		}
 		if r.HTTPSPort != 0 && r.HTTPSPort != 443 {
 			if err := buffer.Write(3); err != nil { return 0, err }
@@ -994,26 +955,20 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 		if len(r.HTTPSEchConfig) > 0 {
 			if err := buffer.Write(5); err != nil { return 0, err }
 			if err := buffer.Writeu16(uint16(len(r.HTTPSEchConfig))); err != nil { return 0, err }
-			for i := 0; i < len(r.HTTPSEchConfig); i++ {
-				if err := buffer.Write(r.HTTPSEchConfig[i]); err != nil { return 0, err }
-			}
+			if err := buffer.WriteRange(buffer.Position(), r.HTTPSEchConfig); err != nil { return 0, err }
 		}
 		if len(r.HTTPSIpv4Hint) > 0 {
 			if err := buffer.Write(6); err != nil { return 0, err }
 			if err := buffer.Writeu16(uint16(len(r.HTTPSIpv4Hint) * 4)); err != nil { return 0, err }
 			for _, ip := range r.HTTPSIpv4Hint {
-				for _, b := range ip.To4() {
-					if err := buffer.Write(b); err != nil { return 0, err }
-				}
+				if err := buffer.WriteRange(buffer.Position(), ip.To4()); err != nil { return 0, err }
 			}
 		}
 		if len(r.HTTPSIpv6Hint) > 0 {
 			if err := buffer.Write(7); err != nil { return 0, err }
 			if err := buffer.Writeu16(uint16(len(r.HTTPSIpv6Hint) * 16)); err != nil { return 0, err }
 			for _, ip := range r.HTTPSIpv6Hint {
-				for _, b := range ip.To16() {
-					if err := buffer.Write(b); err != nil { return 0, err }
-				}
+				if err := buffer.WriteRange(buffer.Position(), ip.To16()); err != nil { return 0, err }
 			}
 		}
 		if r.HTTPSNoDefault {
@@ -1031,9 +986,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 			if err := buffer.Writeu16(0); err != nil { return 0, err }
 		} else {
 			if err := buffer.Writeu16(uint16(len(r.Data))); err != nil { return 0, err } // #nosec G115
-			for _, b := range r.Data {
-				if err := buffer.Write(b); err != nil { return 0, err }
-			}
+			if err := buffer.WriteRange(buffer.Position(), r.Data); err != nil { return 0, err }
 		}
 	}
 

--- a/internal/dns/packet/write_range_test.go
+++ b/internal/dns/packet/write_range_test.go
@@ -1,0 +1,508 @@
+package packet
+
+import (
+	"net"
+	"testing"
+)
+
+// TestWriteRange_LargeNSEC verifies WriteRange handles large TypeBitMap correctly.
+func TestWriteRange_LargeNSEC(t *testing.T) {
+	// Build a TypeBitMap with many record types (larger than typical small tests)
+	// This exercises WriteRange with a larger buffer
+	typeBitmap := make([]byte, 256)
+	for i := range typeBitmap {
+		typeBitmap[i] = byte(i % 256)
+	}
+
+	record := DNSRecord{
+		Name:       "nsec-large.test.",
+		Type:       NSEC,
+		Class:      1,
+		TTL:        300,
+		NextName:   "next.test.",
+		TypeBitMap: typeBitmap,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.TypeBitMap) != len(typeBitmap) {
+		t.Errorf("TypeBitMap length mismatch: got %d, want %d", len(parsed.TypeBitMap), len(typeBitmap))
+	}
+	for i := range parsed.TypeBitMap {
+		if parsed.TypeBitMap[i] != typeBitmap[i] {
+			t.Errorf("TypeBitMap[%d] mismatch: got %v, want %v", i, parsed.TypeBitMap[i], typeBitmap[i])
+		}
+	}
+}
+
+// TestWriteRange_LargeHINFO verifies WriteRange handles long CPU/OS strings.
+func TestWriteRange_LargeHINFO(t *testing.T) {
+	// Use longer strings to exercise WriteRange with larger data
+	cpu := "AMD EPYC 7763 64-Core Processor"
+	os := "Ubuntu 22.04.3 LTS (Jammy Jellyfish)"
+
+	record := DNSRecord{
+		Name: "hinfo-large.test.",
+		Type: HINFO,
+		Class: 1,
+		TTL:   300,
+		CPU:   cpu,
+		OS:    os,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if parsed.CPU != cpu {
+		t.Errorf("CPU mismatch: got %s, want %s", parsed.CPU, cpu)
+	}
+	if parsed.OS != os {
+		t.Errorf("OS mismatch: got %s, want %s", parsed.OS, os)
+	}
+}
+
+// TestWriteRange_LargeCAA verifies WriteRange handles multi-char Tag and Value.
+func TestWriteRange_LargeCAA(t *testing.T) {
+	record := DNSRecord{
+		Name:    "caa-large.test.",
+		Type:    CAA,
+		Class:   1,
+		TTL:     300,
+		CAAFlag: 128,
+		CAATag:  "issuewild",
+		CAAValue: "letsencrypt.org; validation-method=dns-01; notes=Production",
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if parsed.CAAFlag != record.CAAFlag {
+		t.Errorf("CAAFlag mismatch: got %d, want %d", parsed.CAAFlag, record.CAAFlag)
+	}
+	if parsed.CAATag != record.CAATag {
+		t.Errorf("CAATag mismatch: got %s, want %s", parsed.CAATag, record.CAATag)
+	}
+	if parsed.CAAValue != record.CAAValue {
+		t.Errorf("CAAValue mismatch: got %s, want %s", parsed.CAAValue, record.CAAValue)
+	}
+}
+
+// TestWriteRange_LargeDS verifies WriteRange handles a larger digest.
+func TestWriteRange_LargeDS(t *testing.T) {
+	// SHA-256 digest is 32 bytes; use something larger for more coverage
+	digest := make([]byte, 64)
+	for i := range digest {
+		digest[i] = byte(i * 3)
+	}
+
+	record := DNSRecord{
+		Name:         "ds-large.test.",
+		Type:         DS,
+		Class:        1,
+		TTL:          300,
+		KeyTag:       54321,
+		Algorithm:    13,
+		DigestType:   2, // SHA-256
+		Digest:       digest,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.Digest) != len(digest) {
+		t.Errorf("Digest length mismatch: got %d, want %d", len(parsed.Digest), len(digest))
+	}
+	for i := range parsed.Digest {
+		if parsed.Digest[i] != digest[i] {
+			t.Errorf("Digest[%d] mismatch: got %v, want %v", i, parsed.Digest[i], digest[i])
+		}
+	}
+}
+
+// TestWriteRange_LargeDNSKEY verifies WriteRange handles a larger public key.
+func TestWriteRange_LargeDNSKEY(t *testing.T) {
+	// RSA 2048-bit key is ~256 bytes in DNSKEY format
+	publicKey := make([]byte, 256)
+	for i := range publicKey {
+		publicKey[i] = byte((i * 7) % 256)
+	}
+
+	record := DNSRecord{
+		Name:     "dnskey-large.test.",
+		Type:     DNSKEY,
+		Class:    1,
+		TTL:      300,
+		Flags:    257,
+		Algorithm: 8, // RSA/SHA-256
+		PublicKey: publicKey,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.PublicKey) != len(publicKey) {
+		t.Errorf("PublicKey length mismatch: got %d, want %d", len(parsed.PublicKey), len(publicKey))
+	}
+	for i := range parsed.PublicKey {
+		if parsed.PublicKey[i] != publicKey[i] {
+			t.Errorf("PublicKey[%d] mismatch: got %v, want %v", i, parsed.PublicKey[i], publicKey[i])
+		}
+	}
+}
+
+// TestWriteRange_LargeRRSIG verifies WriteRange handles a larger signature.
+func TestWriteRange_LargeRRSIG(t *testing.T) {
+	// A typical RSA signature can be 256+ bytes
+	signature := make([]byte, 256)
+	for i := range signature {
+		signature[i] = byte((i * 11) % 256)
+	}
+
+	record := DNSRecord{
+		Name:         "rrsig-large.test.",
+		Type:         RRSIG,
+		Class:        1,
+		TTL:          300,
+		TypeCovered:  1, // A
+		Algorithm:    8, // RSA/SHA-256
+		Labels:       2,
+		OrigTTL:      3600,
+		Expiration:   2000000000,
+		Inception:    1000000000,
+		KeyTag:       12345,
+		SignerName:   "dnskey.test.",
+		Signature:    signature,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.Signature) != len(signature) {
+		t.Errorf("Signature length mismatch: got %d, want %d", len(parsed.Signature), len(signature))
+	}
+	for i := range parsed.Signature {
+		if parsed.Signature[i] != signature[i] {
+			t.Errorf("Signature[%d] mismatch: got %v, want %v", i, parsed.Signature[i], signature[i])
+		}
+	}
+}
+
+// TestWriteRange_LargeNSEC3 verifies WriteRange handles large Salt, NextHash, TypeBitMap.
+func TestWriteRange_LargeNSEC3(t *testing.T) {
+	salt := make([]byte, 32)
+	for i := range salt {
+		salt[i] = byte(i * 5)
+	}
+	nextHash := make([]byte, 20)
+	for i := range nextHash {
+		nextHash[i] = byte(i * 7)
+	}
+	typeBitmap := make([]byte, 64)
+	for i := range typeBitmap {
+		typeBitmap[i] = byte(i % 256)
+	}
+
+	record := DNSRecord{
+		Name:       "nsec3-large.test.",
+		Type:       NSEC3,
+		Class:      1,
+		TTL:        300,
+		HashAlg:    1, // SHA-1
+		Iterations: 100,
+		Salt:       salt,
+		NextHash:   nextHash,
+		TypeBitMap: typeBitmap,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.Salt) != len(salt) {
+		t.Errorf("Salt length mismatch: got %d, want %d", len(parsed.Salt), len(salt))
+	}
+	if len(parsed.NextHash) != len(nextHash) {
+		t.Errorf("NextHash length mismatch: got %d, want %d", len(parsed.NextHash), len(nextHash))
+	}
+	if len(parsed.TypeBitMap) != len(typeBitmap) {
+		t.Errorf("TypeBitMap length mismatch: got %d, want %d", len(parsed.TypeBitMap), len(typeBitmap))
+	}
+}
+
+// TestWriteRange_LargeHTTPS_IpHints verifies WriteRange with multiple IP hints.
+func TestWriteRange_LargeHTTPS_IpHints(t *testing.T) {
+	ipv4Hints := []net.IP{
+		net.ParseIP("192.0.2.1"),
+		net.ParseIP("192.0.2.2"),
+		net.ParseIP("192.0.2.3"),
+	}
+	ipv6Hints := []net.IP{
+		net.ParseIP("2001:db8::1"),
+		net.ParseIP("2001:db8::2"),
+	}
+
+	record := DNSRecord{
+		Name:           "https-hints-large.test.",
+		Type:           HTTPS,
+		Class:          1,
+		TTL:            300,
+		HTTPSPriority:  1,
+		HTTPSTarget:    "target.test.",
+		HTTPSIpv4Hint:  ipv4Hints,
+		HTTPSIpv6Hint:  ipv6Hints,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.HTTPSIpv4Hint) != len(ipv4Hints) {
+		t.Errorf("IPv4 hint count mismatch: got %d, want %d", len(parsed.HTTPSIpv4Hint), len(ipv4Hints))
+	}
+	if len(parsed.HTTPSIpv6Hint) != len(ipv6Hints) {
+		t.Errorf("IPv6 hint count mismatch: got %d, want %d", len(parsed.HTTPSIpv6Hint), len(ipv6Hints))
+	}
+	for i, ip := range parsed.HTTPSIpv4Hint {
+		if !ip.Equal(ipv4Hints[i]) {
+			t.Errorf("HTTPSIpv4Hint[%d] mismatch: got %v, want %v", i, ip, ipv4Hints[i])
+		}
+	}
+	for i, ip := range parsed.HTTPSIpv6Hint {
+		if !ip.Equal(ipv6Hints[i]) {
+			t.Errorf("HTTPSIpv6Hint[%d] mismatch: got %v, want %v", i, ip, ipv6Hints[i])
+		}
+	}
+}
+
+// TestWriteRange_TSIGMAC verifies WriteRange with large TSIG MAC.
+func TestWriteRange_TSIGMAC(t *testing.T) {
+	mac := make([]byte, 64)
+	for i := range mac {
+		mac[i] = byte(i * 3)
+	}
+	other := make([]byte, 32)
+	for i := range other {
+		other[i] = byte(i * 7)
+	}
+
+	record := DNSRecord{
+		Name:          "tsig-large.test.",
+		Type:          TSIG,
+		Class:         0,
+		TTL:           0,
+		AlgorithmName: "hmac-sha256.",
+		TimeSigned:    1234567890,
+		Fudge:         300,
+		MAC:           mac,
+		OriginalID:    1,
+		Error:         0,
+		Other:         other,
+	}
+
+	buf := NewBytePacketBuffer()
+	_, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	data := make([]byte, buf.Position())
+	copy(data, buf.Buf[:buf.Position()])
+
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(data)
+
+	var parsed DNSRecord
+	if err := parsed.Read(readBuf); err != nil {
+		t.Fatalf("Read failed: %v", err)
+	}
+
+	if len(parsed.MAC) != len(mac) {
+		t.Errorf("MAC length mismatch: got %d, want %d", len(parsed.MAC), len(mac))
+	}
+	if len(parsed.Other) != len(other) {
+		t.Errorf("Other length mismatch: got %d, want %d", len(parsed.Other), len(other))
+	}
+	for i := range parsed.MAC {
+		if parsed.MAC[i] != mac[i] {
+			t.Errorf("MAC[%d] mismatch", i)
+		}
+	}
+	for i := range parsed.Other {
+		if parsed.Other[i] != other[i] {
+			t.Errorf("Other[%d] mismatch", i)
+		}
+	}
+}
+
+// TestWriteRange_GenericLargeData verifies WriteRange with large generic Data.
+// Note: the Read path for generic types steps over RDATA without populating r.Data,
+// so this test validates the write path via buffer contents.
+func TestWriteRange_GenericLargeData(t *testing.T) {
+	data := make([]byte, 512)
+	for i := range data {
+		data[i] = byte((i * 13) % 256)
+	}
+
+	record := DNSRecord{
+		Name:  "generic-large.test.",
+		Type:  UNKNOWN,
+		Class: 1,
+		TTL:   300,
+		Data:  data,
+	}
+
+	buf := NewBytePacketBuffer()
+	written, err := record.Write(buf)
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Verify the written size matches expectations
+	// RDLENGTH field at offset (name + type + class + ttl = variable + 10 bytes)
+	// We just verify total bytes written is reasonable for 512-byte payload + header
+	if written < 530 {
+		t.Errorf("Written size too small: got %d, want >= 530", written)
+	}
+
+	// Read the RDLENGTH and verify it matches the data length
+	// Skip name (compressed) and fixed fields, then read RDLENGTH
+	readBuf := NewBytePacketBuffer()
+	readBuf.Load(buf.Buf[:buf.Position()])
+
+	// Read name
+	_, _ = readBuf.ReadName()
+	// Read type (2 bytes)
+	readBuf.Step(2)
+	// Read class (2 bytes)
+	readBuf.Step(2)
+	// Read TTL (4 bytes)
+	readBuf.Step(4)
+	// Read RDLENGTH (2 bytes)
+	rdLength, err := readBuf.Readu16()
+	if err != nil {
+		t.Fatalf("Failed to read RDLENGTH: %v", err)
+	}
+	if rdLength != 512 {
+		t.Errorf("RDLENGTH mismatch: got %d, want 512", rdLength)
+	}
+
+	// Read RDATA bytes and verify content
+	rdata := make([]byte, 512)
+	copy(rdata, readBuf.Buf[readBuf.Position():readBuf.Position()+512])
+	for i := range rdata {
+		if rdata[i] != data[i] {
+			t.Errorf("RDATA[%d] mismatch: got %v, want %v", i, rdata[i], data[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Replace all byte-by-byte `Write()` loops in `DNSRecord.Write()` with single `WriteRange()` calls
- Each `buffer.Write(b)` acquired/released a mutex per byte; `WriteRange` does one `copy()` with no per-byte mutex overhead
- Affected record types: A, AAAA, TXT, HINFO, DNSKEY, RRSIG, NSEC, NSEC3, DS, CAA, HTTPS (ECH config, IPv4/IPv6 hints), TSIG (MAC, Other), OPT options, generic Data
- A record: 4 mutex ops → 1, AAAA: 16 → 1, DNSKEY: variable → 1, etc.

## Test plan
- [x] `go build ./...`
- [x] `go test -short -timeout 5m ./internal/dns/packet/...`
- [x] `go test -short -timeout 5m ./internal/dns/server/...`