### PR TITLE
Lower TSIG key name log level from WARN to DEBUG

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -738,7 +738,7 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 		tsig := request.Resources[len(request.Resources)-1]
 		secret, ok := s.TsigKeys[tsig.Name]
 		if !ok {
-			s.Logger.Warn("AXFR failed: unknown TSIG key", "key", tsig.Name, "zone", q.Name)
+			s.Logger.Debug("AXFR failed: unknown TSIG key", "key", tsig.Name, "zone", q.Name)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}
@@ -1404,7 +1404,7 @@ func (s *Server) handleUpdate(ctx context.Context, request *packet.DNSPacket, ra
 		tsig := request.Resources[len(request.Resources)-1]
 		secret, ok := s.TsigKeys[tsig.Name]
 		if !ok {
-			s.Logger.Warn("update failed: unknown TSIG key", "key", tsig.Name)
+			s.Logger.Debug("update failed: unknown TSIG key", "key", tsig.Name)
 			response.Header.ResCode = packet.RcodeNotAuth
 			return s.sendUpdateResponse(response, sendFn)
 		}
@@ -1519,7 +1519,7 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 		tsig := request.Resources[len(request.Resources)-1]
 		secret, ok := s.TsigKeys[tsig.Name]
 		if !ok {
-			s.Logger.Warn("IXFR failed: unknown TSIG key", "key", tsig.Name, "zone", q.Name)
+			s.Logger.Debug("IXFR failed: unknown TSIG key", "key", tsig.Name, "zone", q.Name)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}


### PR DESCRIPTION
## Summary
- Change `s.Logger.Warn` to `s.Logger.Debug` at 3 TSIG key failure sites in `server.go`
- Key names are sensitive identifiers — logging them at WARN level could aid targeted key-guessing attacks
- The failure reason and zone name remain available at DEBUG level for debugging

Closes #164