### PR TITLE
fix: resolve four concurrency issues (#189, #179, #176, #190)

### DIFF
--- a/internal/adapters/api/middleware.go
+++ b/internal/adapters/api/middleware.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/poyrazK/cloudDNS/internal/core/domain"
@@ -25,11 +26,32 @@ const CtxRole contextKey = "role"
 
 // TrustedProxyCIDRs contains CIDR ranges for trusted proxies.
 // If set, only requests from these IPs will have X-Real-IP/X-Forwarded-For honored.
-var TrustedProxyCIDRs []*net.IPNet
+// Use SetTrustedProxyCIDRs to update safely.
+var (
+	trustedProxyCIDRsMu sync.RWMutex
+	TrustedProxyCIDRs   []*net.IPNet
+)
+
+// SetTrustedProxyCIDRs updates the trusted proxy CIDRs list safely.
+func SetTrustedProxyCIDRs(cidrs []*net.IPNet) {
+	trustedProxyCIDRsMu.Lock()
+	defer trustedProxyCIDRsMu.Unlock()
+	TrustedProxyCIDRs = cidrs
+}
+
+// getTrustedProxyCIDRs returns a copy of the current trusted proxy CIDRs.
+func getTrustedProxyCIDRs() []*net.IPNet {
+	trustedProxyCIDRsMu.RLock()
+	defer trustedProxyCIDRsMu.RUnlock()
+	result := make([]*net.IPNet, len(TrustedProxyCIDRs))
+	copy(result, TrustedProxyCIDRs)
+	return result
+}
 
 // isFromTrustedProxy returns true if the remote address is from a trusted proxy.
 func isFromTrustedProxy(remoteAddr string) bool {
-	if len(TrustedProxyCIDRs) == 0 {
+	cidrs := getTrustedProxyCIDRs()
+	if len(cidrs) == 0 {
 		return false
 	}
 	ip, _, err := net.SplitHostPort(remoteAddr)
@@ -40,7 +62,7 @@ func isFromTrustedProxy(remoteAddr string) bool {
 	if parsedIP == nil {
 		return false
 	}
-	for _, cidr := range TrustedProxyCIDRs {
+	for _, cidr := range cidrs {
 		if cidr.Contains(parsedIP) {
 			return true
 		}

--- a/internal/adapters/api/middleware_test.go
+++ b/internal/adapters/api/middleware_test.go
@@ -167,10 +167,10 @@ func TestRequireRole(t *testing.T) {
 
 func TestClientIP(t *testing.T) {
 	// Set up trusted proxy CIDR for tests
-	originalCIDRs := TrustedProxyCIDRs
-	defer func() { TrustedProxyCIDRs = originalCIDRs }()
+	originalCIDRs := getTrustedProxyCIDRs()
+	defer SetTrustedProxyCIDRs(originalCIDRs)
 	_, trustedCIDR, _ := net.ParseCIDR("192.168.1.0/24")
-	TrustedProxyCIDRs = []*net.IPNet{trustedCIDR}
+	SetTrustedProxyCIDRs([]*net.IPNet{trustedCIDR})
 
 	tests := []struct {
 		name     string

--- a/internal/dns/server/ratelimit.go
+++ b/internal/dns/server/ratelimit.go
@@ -129,8 +129,10 @@ func (rl *rateLimiter) Allow(ip string) bool {
 	elapsed := now.Sub(b.last).Seconds()
 	b.last = now
 
-	// Update heap position after last change
-	heap.Fix(&shard.idleHeap, b.heapIdx)
+	// Update heap position after last change (heapIdx may be -1 if bucket was evicted by Cleanup but not yet removed from map)
+	if b.heapIdx != -1 {
+		heap.Fix(&shard.idleHeap, b.heapIdx)
+	}
 
 	// Refill
 	b.tokens += elapsed * shard.rate

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -494,9 +494,9 @@ func (s *Server) Run(ctx context.Context) error {
 						_ = c.SetReadDeadline(time.Now().Add(udpReadDeadline))
 						continue
 					}
-					// buf[:n:n] shares the backing array — the channel send completes
-					// before the next ReadFrom, so the array is not overwritten.
-					data := buf[:n:n]
+					// Copy buffer since the backing array is reused across ReadFrom calls.
+					data := make([]byte, n)
+					copy(data, buf[:n])
 					s.udpQueue <- udpTask{addr: addr, data: data, conn: c}
 				}
 			}
@@ -959,9 +959,10 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	}
 	cacheKey := fmt.Sprintf("%s:%d", strings.ToLower(q.Name), q.QType)
 
-	// L1/L2 Check — acquire per-key lock only for atomic check-and-populate.
-	// Lock is NOT held during L3 resolution to avoid serializing concurrent requests
-	// that map to the same shard but have different cache keys.
+	// L1/L2 Check — acquire per-key lock for atomic check-and-populate.
+	// Lock IS held during L3 resolution to prevent cache stampede — multiple
+	// concurrent requests for the same cache key would all hit L3 if the lock
+	// were released before resolution completes.
 	lock := globalCacheLocks.lockKey(cacheKey)
 	lock.Lock()
 
@@ -1004,9 +1005,8 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 		}
 	}
 
-	lock.Unlock()
-
 	if cachedData != nil {
+		lock.Unlock()
 		return sendFn(cachedData)
 	}
 
@@ -1337,6 +1337,7 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 
 	metrics.QueriesTotal.WithLabelValues(qTypeLabel, fmt.Sprintf("%d", response.Header.ResCode), protocol).Inc()
 	s.Logger.Info("query processed", "name", q.Name, "src", source, "lat", time.Since(start).Milliseconds())
+	lock.Unlock()
 	return sendFn(resData)
 }
 


### PR DESCRIPTION
## Summary

Fix four high-severity concurrency bugs identified in the issue tracker:

- **#189 UDP buffer reuse race**: Copy buffer data before sending to `udpQueue` to prevent data corruption under high load when `ReadFrom` overwrites the shared backing array before the consumer processes the previous packet.
- **#179 Cache stampede**: Hold per-key lock through L3 (database) resolution to prevent thundering herd — without this, concurrent requests for the same cache key all proceed to the database after the lock is released at the wrong point.
- **#190 Rate limiter heap panic**: Guard `heap.Fix` call with `heapIdx != -1` check. The `Cleanup` goroutine can evict a bucket from the heap (setting `heapIdx = -1`) while `Allow()` still holds a reference to it in `shard.buckets`, causing an out-of-bounds heap operation.
- **#176 TrustedProxyCIDRs race**: Add `sync.RWMutex` around the global `TrustedProxyCIDRs` variable accessed during request handling without synchronization.

## Testing

- `go build ./...` passes
- `go test -timeout 5m ./...` passes (all packages)
- `go test -race -timeout 5m ./...` passes — no races detected

## Files changed

| File | Change |
|------|--------|
| `internal/dns/server/server.go` | UDP buffer copy + cache stampede fix |
| `internal/dns/server/ratelimit.go` | heapIdx guard for heap.Fix |
| `internal/adapters/api/middleware.go` | RWMutex for TrustedProxyCIDRs |

---

Fixes #189
Fixes #179
Fixes #176
Fixes #190