### PR TITLE
fix: security hardening (NOTIFY auth, hardcoded credentials, HTTP timeouts)

### DIFF
--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -65,7 +65,7 @@ func replaceDSNParam(dbURL, param, value string) string {
 // Exported for testing.
 func processDatabaseURL(dbURL, hostOverride string) string {
 	if dbURL == "" {
-		dbURL = "postgres://postgres:postgres@localhost:5432/clouddns?sslmode=disable"
+		return "" // Require explicit DATABASE_URL
 	}
 
 	if hostOverride == "" {

--- a/cmd/clouddns/main_test.go
+++ b/cmd/clouddns/main_test.go
@@ -389,12 +389,12 @@ func TestProcessDatabaseURL(t *testing.T) {
 			hostOverride: "",
 			wantSSLMode:  "verify-full",
 		},
-		// Default URL when empty
+		// Default URL when empty - now requires explicit DATABASE_URL
 		{
-			name:         "Empty URL uses default with disable",
+			name:         "Empty URL returns empty string",
 			dbURL:        "",
 			hostOverride: "127.0.0.1",
-			wantSSLMode:  "disable",
+			wantSSLMode:  "",
 		},
 		// DSN format - localhost disables SSL
 		{

--- a/cmd/iana-import/main.go
+++ b/cmd/iana-import/main.go
@@ -32,7 +32,7 @@ func main() {
 func Run([]string) error {
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://postgres:postgres@localhost:5432/clouddns?sslmode=disable"
+		return fmt.Errorf("DATABASE_URL environment variable is required")
 	}
 
 	db, err := sql.Open("pgx", dbURL)
@@ -55,8 +55,8 @@ func Run([]string) error {
 
 func RunImport(ctx context.Context, repo ports.DNSRepository, url string) error {
 	fmt.Printf("Downloading IANA root zone from %s...\n", url)
-	// #nosec G107 -- URL is trusted IANA source
-	resp, err := http.Get(url)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed to download: %w", err)
 	}

--- a/cmd/top1m-import/main.go
+++ b/cmd/top1m-import/main.go
@@ -26,7 +26,7 @@ const top1mURL = "http://s3-us-west-1.amazonaws.com/umbrella-static/top-1m.csv.z
 func main() {
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		dbURL = "postgres://postgres:postgres@localhost:5432/clouddns?sslmode=disable"
+		slog.Error("DATABASE_URL environment variable is required"); os.Exit(1)
 	}
 
 	db, err := sql.Open("pgx", dbURL)
@@ -40,7 +40,8 @@ func main() {
 	}()
 
 	fmt.Printf("Downloading Top 1M list from %s...\n", top1mURL)
-	resp, err := http.Get(top1mURL)
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(top1mURL)
 	if err != nil {
 		slog.Error("failed to download", "error", err); os.Exit(1)
 	}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1413,24 +1413,16 @@ func (s *Server) handleNotify(ctx context.Context, request *packet.DNSPacket, cl
 	response.Header.AuthoritativeAnswer = true
 	response.Questions = append(response.Questions, request.Questions[0])
 
-	// Trigger async refresh if it's a slave zone
-	if !s.DisableAsync {
-		go func(zoneName string) {
-			// Check for cancellation or shutdown before starting long-running operations.
-			select {
-			case <-ctx.Done():
-				return
-			case <-s.done:
-				return
-			default:
-			}
-			zone, err := s.Repo.GetZone(ctx, zoneName)
-			if err != nil {
-				s.Logger.Error("failed to fetch zone for notify refresh", "zone", zoneName, "error", err)
-				return
-			}
-			if zone != nil && zone.Role == "slave" {
-				// Check again before refresh to avoid unnecessary work during shutdown.
+	// For slave zones, validate source is the configured master before triggering refresh
+	zone, err := s.Repo.GetZone(ctx, request.Questions[0].Name)
+	if err != nil {
+		s.Logger.Error("failed to fetch zone for notify", "zone", request.Questions[0].Name, "error", err)
+	}
+	if zone != nil && zone.Role == "slave" && zone.MasterServer != "" {
+		if !isAuthorizedNotifier(clientIP, zone.MasterServer) {
+			s.Logger.Warn("NOTIFY rejected: unauthorized source", "from", clientIP, "master", zone.MasterServer)
+		} else if !s.DisableAsync {
+			go func(zoneName string) {
 				select {
 				case <-ctx.Done():
 					return
@@ -1438,13 +1430,40 @@ func (s *Server) handleNotify(ctx context.Context, request *packet.DNSPacket, cl
 					return
 				default:
 				}
-				s.refreshZone(ctx, zone)
-			}
-		}(request.Questions[0].Name)
+				if z, err := s.Repo.GetZone(ctx, zoneName); err == nil && z != nil {
+					s.refreshZone(ctx, z)
+				}
+			}(request.Questions[0].Name)
+		}
 	}
 
 	response.Header.ResCode = packet.RcodeNoError
 	return s.sendUpdateResponse(response, sendFn)
+}
+
+// isAuthorizedNotifier checks if the source IP is authorized to send NOTIFY for the zone.
+func isAuthorizedNotifier(clientIP, masterServer string) bool {
+	// Extract host from masterServer (may be "host:port" format)
+	masterHost, _, err := net.SplitHostPort(masterServer)
+	if err != nil {
+		masterHost = masterServer // No port in config, use as-is
+	}
+
+	// If master is an IP, compare directly
+	if net.ParseIP(masterHost) != nil {
+		return clientIP == masterHost
+	}
+
+	// Master is a hostname — resolve and compare IPs
+	addrs, err := net.ResolveTCPAddr("tcp", masterHost+":0")
+	if err != nil {
+		return false
+	}
+	clientParsed := net.ParseIP(clientIP)
+	if clientParsed == nil {
+		return false
+	}
+	return clientParsed.Equal(addrs.IP)
 }
 
 // handleUpdate processes a DNS dynamic update (RFC 2136) request.


### PR DESCRIPTION
## Summary

Three security hardening fixes:

- **#182 NOTIFY handler no source validation**: Only trigger zone refresh for slave zones if source IP matches the zone's `MasterServer`. Unauthorized sources log a warning but don't trigger refresh.
- **#174 Hardcoded database credentials**: CLI tools now require explicit `DATABASE_URL` instead of falling back to `postgres://postgres:postgres@localhost:5432/clouddns?sslmode=disable`.
- **#175 HTTP requests without timeouts**: Import tools now use `http.Client{Timeout: 30 * time.Second}` instead of unbounded `http.Get()`.

## Testing

- `go build ./...` passes
- `go test -timeout 5m ./...` passes (all packages)
- `go test -race -timeout 5m ./...` passes

## Files changed

| File | Change |
|------|--------|
| `internal/dns/server/server.go` | NOTIFY source validation + isAuthorizedNotifier helper |
| `cmd/clouddns/main.go` | Remove hardcoded credential fallback |
| `cmd/clouddns/main_test.go` | Update test for empty URL behavior |
| `cmd/iana-import/main.go` | Remove hardcoded credentials + add HTTP timeout |
| `cmd/top1m-import/main.go` | Remove hardcoded credentials + add HTTP timeout |

---

Fixes #182
Fixes #174
Fixes #175