### PR TITLE
fix: panic prevention and data integrity

### DIFF
--- a/internal/adapters/repository/postgres.go
+++ b/internal/adapters/repository/postgres.go
@@ -530,9 +530,12 @@ func (r *PostgresRepository) CreateZoneWithRecords(ctx context.Context, zone *do
 	if errTx != nil {
 		return errTx
 	}
+	committed := false
 	defer func() {
-		if errRollback := tx.Rollback(); errRollback != nil && !errors.Is(errRollback, sql.ErrTxDone) {
-			r.logger.Error("failed to rollback transaction", "error", errRollback)
+		if !committed {
+			if errRollback := tx.Rollback(); errRollback != nil && !errors.Is(errRollback, sql.ErrTxDone) {
+				r.logger.Error("failed to rollback transaction", "error", errRollback)
+			}
 		}
 	}()
 
@@ -573,7 +576,11 @@ func (r *PostgresRepository) CreateZoneWithRecords(ctx context.Context, zone *do
 		}
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 // CreateRecord implements ports.DNSRepository.

--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -669,9 +669,10 @@ func (r *DNSRecord) Read(buffer *BytePacketBuffer) error {
 			case 2: // no-default
 				r.HTTPSNoDefault = true
 			case 3: // port
-				if len(paramData) >= 2 {
-					r.HTTPSPort = uint16(paramData[0])<<8 | uint16(paramData[1]) // #nosec G115
+				if len(paramData) < 2 {
+					return fmt.Errorf("HTTPS SVCB param port: length %d less than 2", len(paramData))
 				}
+				r.HTTPSPort = uint16(paramData[0])<<8 | uint16(paramData[1]) // #nosec G115
 			case 5: // echconfig
 				r.HTTPSEchConfig = paramData
 			case 6: // ipv4hint

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -746,7 +746,7 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 	}
 
 	// Validate TSIG if present
-	if request.TSIGStart != -1 {
+	if request.TSIGStart != -1 && len(request.Resources) > 0 {
 		tsig := request.Resources[len(request.Resources)-1]
 		secret, ok := s.TsigKeys[tsig.Name]
 		if !ok {
@@ -1490,7 +1490,7 @@ func (s *Server) handleUpdate(ctx context.Context, request *packet.DNSPacket, ra
 	response.Header.Opcode = packet.OpcodeUpdate
 
 	// 1. Validate TSIG if present
-	if request.TSIGStart != -1 {
+	if request.TSIGStart != -1 && len(request.Resources) > 0 {
 		tsig := request.Resources[len(request.Resources)-1]
 		secret, ok := s.TsigKeys[tsig.Name]
 		if !ok {
@@ -1606,7 +1606,7 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 	}
 
 	// Validate TSIG if present
-	if request.TSIGStart != -1 {
+	if request.TSIGStart != -1 && len(request.Resources) > 0 {
 		tsig := request.Resources[len(request.Resources)-1]
 		secret, ok := s.TsigKeys[tsig.Name]
 		if !ok {


### PR DESCRIPTION
## Summary

Three fixes preventing crashes and data inconsistency:

- **#187 HTTPS SVCB param port bounds check**: Return error when param length < 2 instead of silently doing nothing.
- **#181 TSIG panic prevention**: Add `len(request.Resources) > 0` check on all 3 TSIG validation sites (AXFR, Update, IXFR handlers).
- **#184 Deferred rollback mask**: Use `committed` flag so rollback only runs if commit hasn't succeeded, preventing masked commit failures.

## Testing

- `go build ./...` passes
- `go test -timeout 5m ./...` passes (all packages)
- `go test -race -timeout 5m ./...` passes

## Files changed

| File | Change |
|------|--------|
| `internal/dns/packet/packet.go` | SVCB port bounds error |
| `internal/dns/server/server.go` | TSIG Resources bounds check (3 sites) |
| `internal/adapters/repository/postgres.go` | committed flag for deferred rollback |

---

Fixes #187
Fixes #181
Fixes #184