### PR TITLE
perf(packet): eliminate allocations in WriteName

### DIFF
--- a/internal/dns/packet/buffer.go
+++ b/internal/dns/packet/buffer.go
@@ -320,25 +320,32 @@ func (b *BytePacketBuffer) WriteName(name string) error {
 		name += "."
 	}
 
+	// Pre-compute lowercase once for compression map lookups
+	var lowerName string
+	if b.HasNames {
+		lowerName = strings.ToLower(name)
+	}
+
 	curr := name
+	lowerCurr := lowerName
 	for {
 		if curr == "" || curr == "." {
 			return b.Write(0)
 		}
 
 		if b.HasNames {
-			lower := strings.ToLower(curr)
-			if pos, ok := b.names[lower]; ok {
+			if pos, ok := b.names[lowerCurr]; ok {
 				// Compression pointer: high bits 11, low bits are offset
 				offset := uint16(0xC000) | uint16(pos&0x3FFF)
 				return b.Writeu16(offset)
 			}
 			if b.Pos < 0x4000 {
-				b.names[lower] = b.Pos
+				b.names[lowerCurr] = b.Pos
 			}
 		}
 
 		dotIdx := strings.IndexByte(curr, '.')
+		lowerDotIdx := strings.IndexByte(lowerCurr, '.')
 		if dotIdx == -1 {
 			return b.Write(0)
 		}
@@ -351,13 +358,12 @@ func (b *BytePacketBuffer) WriteName(name string) error {
 			if err := b.WriteUint8(len(label)); err != nil {
 				return err
 			}
-			for i := 0; i < len(label); i++ {
-				if err := b.Write(label[i]); err != nil {
-					return err
-				}
+			if err := b.WriteRange(b.Pos, []byte(label)); err != nil {
+				return err
 			}
 		}
 		curr = curr[dotIdx+1:]
+		lowerCurr = lowerCurr[lowerDotIdx+1:]
 	}
 }
 
@@ -390,10 +396,8 @@ func (b *BytePacketBuffer) WriteNameUncompressed(name string) error {
 			if err := b.WriteUint8(len(label)); err != nil {
 				return err
 			}
-			for i := 0; i < len(label); i++ {
-				if err := b.Write(label[i]); err != nil {
-					return err
-				}
+			if err := b.WriteRange(b.Pos, []byte(label)); err != nil {
+				return err
 			}
 		}
 		curr = curr[dotIdx+1:]

--- a/internal/dns/packet/buffer.go
+++ b/internal/dns/packet/buffer.go
@@ -358,7 +358,7 @@ func (b *BytePacketBuffer) WriteName(name string) error {
 			if err := b.WriteUint8(len(label)); err != nil {
 				return err
 			}
-			if err := b.WriteRange(b.Pos, []byte(label)); err != nil {
+			if err := b.WriteStringRange(b.Pos, label); err != nil {
 				return err
 			}
 		}
@@ -396,7 +396,7 @@ func (b *BytePacketBuffer) WriteNameUncompressed(name string) error {
 			if err := b.WriteUint8(len(label)); err != nil {
 				return err
 			}
-			if err := b.WriteRange(b.Pos, []byte(label)); err != nil {
+			if err := b.WriteStringRange(b.Pos, label); err != nil {
 				return err
 			}
 		}
@@ -406,6 +406,21 @@ func (b *BytePacketBuffer) WriteNameUncompressed(name string) error {
 
 // WriteRange writes a slice of bytes at a specific position
 func (b *BytePacketBuffer) WriteRange(start int, data []byte) error {
+	if start+len(data) > MaxPacketSize {
+		return errors.New("out of bounds")
+	}
+	copy(b.Buf[start:start+len(data)], data)
+	if start+len(data) > b.Pos {
+		b.Pos = start + len(data)
+	}
+	if b.Pos > b.Len {
+		b.Len = b.Pos
+	}
+	return nil
+}
+
+// WriteStringRange writes a string at a specific position without allocating a []byte.
+func (b *BytePacketBuffer) WriteStringRange(start int, data string) error {
 	if start+len(data) > MaxPacketSize {
 		return errors.New("out of bounds")
 	}

--- a/internal/dns/packet/buffer_test.go
+++ b/internal/dns/packet/buffer_test.go
@@ -70,6 +70,30 @@ func TestBufferMutators(t *testing.T) {
 	if err := buf.WriteRange(MaxPacketSize, []byte{1}); err == nil {
 		t.Errorf("WriteRange out of bounds should fail")
 	}
+
+	// Test WriteStringRange
+	_ = buf.WriteStringRange(30, "hello")
+	got, _ = buf.GetRange(30, 5)
+	if string(got) != "hello" {
+		t.Errorf("WriteStringRange failed: expected 'hello', got '%s'", string(got))
+	}
+
+	// Test WriteStringRange out of bounds
+	if err := buf.WriteStringRange(MaxPacketSize, "x"); err == nil {
+		t.Errorf("WriteStringRange out of bounds should fail")
+	}
+
+	// Test WriteStringRange with MaxPacketSize - 1 (just within bounds)
+	buf.Reset()
+	if err := buf.WriteStringRange(MaxPacketSize-3, "abc"); err != nil {
+		t.Errorf("WriteStringRange at MaxPacketSize-3 should succeed: %v", err)
+	}
+
+	// Test WriteStringRange exactly at limit
+	buf.Reset()
+	if err := buf.WriteStringRange(MaxPacketSize-1, "a"); err != nil {
+		t.Errorf("WriteStringRange at MaxPacketSize-1 should succeed: %v", err)
+	}
 }
 
 func TestBuffer_ReadErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
- Pre-compute `strings.ToLower()` once per name instead of per label (eliminates N allocations for N-label name)
- Add `WriteStringRange(start int, data string)` method to write strings directly without `[]byte` allocation
- Replace `b.WriteRange(b.Pos, []byte(label))` with `b.WriteStringRange(b.Pos, label)` in WriteName and WriteNameUncompressed
- Fix `lowerDotIdx` bug where Unicode lowercase may differ in byte representation

## Test plan
- [x] go test -short ./...
- [x] go test -short ./internal/dns/packet/... (WriteStringRange tests added)
- [ ] Run benchmark before/after comparison