### PR TITLE
First sprint: DNS packet parsing validation fixes

### DIFF
--- a/internal/dns/packet/buffer.go
+++ b/internal/dns/packet/buffer.go
@@ -207,6 +207,9 @@ func (b *BytePacketBuffer) ReadName() (string, error) {
 				return "", err
 			}
 			offset := ((uint16(lenByte) ^ 0xC0) << 8) | uint16(b2)
+			if offset >= uint16(b.Len) {
+				return "", errors.New("out of bounds")
+			}
 			pos = int(offset)
 			jumped = true
 			jumpsPerformed++
@@ -217,6 +220,9 @@ func (b *BytePacketBuffer) ReadName() (string, error) {
 		pos++
 		lenInt := int(lenByte)
 
+		if lenByte > 63 {
+			return "", errors.New("label too long")
+		}
 		if pos+lenInt > b.Len {
 			return "", errors.New("out of bounds")
 		}


### PR DESCRIPTION
## Summary
- **API Key TenantID validation**: Reject API keys with empty TenantID in middleware
- **ApplyZoneUpdate tenant verification**: Added `tenantID` parameter and zone ownership check inside transaction
- **AXFR/IXFR require TSIG**: Zone transfers now require TSIG authentication - rejects without TSIG with NotAuth
- **Wildcard cache key tenant isolation**: Changed cache key format to include tenant/zone ID

## Changes

### `internal/adapters/api/middleware.go`
- Empty TenantID validation after API key lookup

### `internal/core/ports/ports.go`
- Added `tenantID` parameter to `ApplyZoneUpdate` interface

### `internal/adapters/repository/postgres.go`
- Zone ownership verification inside transaction
- TenantID parameter added to `ApplyZoneUpdate`

### `internal/dns/server/server.go`
- AXFR and IXFR now require TSIG (changed from optional)
- Cache key format changed to `{tenantID}:{zoneID}:{name}:{qtype}`
- Zone lookup moved before cache check for tenant isolation

## Verification
- `go test -short -timeout 5m ./...`

## Fixes
Fixes #260
Fixes #256
Fixes #259
Fixes #238
Fixes #235