### PR TITLE
perf(hotpath): eliminate repeated work in cache hit and recursive resolution paths

### DIFF
--- a/internal/dns/server/recursive.go
+++ b/internal/dns/server/recursive.go
@@ -20,6 +20,26 @@ type recursiveResolver struct {
 	fallbacks []string
 }
 
+// Package-level constants for IANA root servers to avoid allocation per resolution.
+// These are static values that never change.
+var ianaRootHints = []string{
+	"198.41.0.4",     // a.root-servers.net
+	"170.247.170.2",  // b.root-servers.net
+	"192.33.4.12",    // c.root-servers.net
+	"199.7.91.13",    // d.root-servers.net
+	"192.203.230.10", // e.root-servers.net
+	"192.5.5.241",    // f.root-servers.net
+	"192.112.36.4",   // g.root-servers.net
+	"198.97.190.53",  // h.root-servers.net
+	"192.36.148.17",  // i.root-servers.net
+	"192.58.128.30",  // j.root-servers.net
+	"193.0.14.129",   // k.root-servers.net
+	"199.7.83.42",    // l.root-servers.net
+	"202.12.27.33",   // m.root-servers.net
+}
+
+var fallbackResolvers = []string{"8.8.8.8", "1.1.1.1"}
+
 // recursiveTimeout is the maximum time allowed for recursive resolution.
 // Defaults to 30s but can be overridden in tests.
 var recursiveTimeout = 30 * time.Second
@@ -27,25 +47,8 @@ var recursiveTimeout = 30 * time.Second
 // newRecursiveResolver creates a recursive resolver with IANA root server hints and fallback resolvers.
 func newRecursiveResolver() *recursiveResolver {
 	return &recursiveResolver{
-		rootHints: []string{
-			"198.41.0.4",     // a.root-servers.net
-			"170.247.170.2",  // b.root-servers.net
-			"192.33.4.12",    // c.root-servers.net
-			"199.7.91.13",    // d.root-servers.net
-			"192.203.230.10", // e.root-servers.net
-			"192.5.5.241",    // f.root-servers.net
-			"192.112.36.4",   // g.root-servers.net
-			"198.97.190.53",  // h.root-servers.net
-			"192.36.148.17",  // i.root-servers.net
-			"192.58.128.30",  // j.root-servers.net
-			"193.0.14.129",   // k.root-servers.net
-			"199.7.83.42",    // l.root-servers.net
-			"202.12.27.33",   // m.root-servers.net
-		},
-		fallbacks: []string{
-			"8.8.8.8", // Google
-			"1.1.1.1", // Cloudflare
-		},
+		rootHints: ianaRootHints,  // Reference to package-level constant, no copy
+		fallbacks: fallbackResolvers,
 	}
 }
 

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -118,6 +118,9 @@ type Server struct {
 	// inflightCache prevents thundering herd: tracks keys currently being fetched from L2.
 	// Key -> *inflightEntry (done channel closed when fetch completes).
 	inflightCache sync.Map
+
+	// l1TTLCap is cached at startup to avoid repeated os.Getenv calls in hot path
+	l1TTLCap time.Duration
 }
 
 // inflightEntry holds state for an in-progress L2 cache fetch.
@@ -167,6 +170,14 @@ func NewServer(addr string, repo ports.DNSRepository, logger *slog.Logger) *Serv
 	s.done = make(chan struct{})
 	_, _ = crand.Read(s.CookieSecret)
 	s.queryFn = s.sendQuery
+
+	// Cache REDIS_L1_TTL_CAP at startup to avoid repeated os.Getenv in hot path
+	s.l1TTLCap = 300 * time.Second
+	if v := os.Getenv("REDIS_L1_TTL_CAP"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
+			s.l1TTLCap = time.Duration(secs) * time.Second
+		}
+	}
 
 	// Initialize caches with done channel for graceful shutdown
 	s.Cache = NewDNSCache(s.done, &s.wg)
@@ -936,9 +947,10 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 
 	q := request.Questions[0]
 
-	// CHAOS identity queries
+	// CHAOS identity queries - compute lowerName once
+	lowerName := strings.ToLower(q.Name)
 	if q.QClass == ClassCHAOS {
-		if strings.ToLower(q.Name) == "id.server." || strings.ToLower(q.Name) == "hostname.bind." {
+		if lowerName == "id.server." || lowerName == "hostname.bind." {
 			return s.sendCHAOSIdentity(request, q, sendFn, qTypeLabel, protocol)
 		}
 	}
@@ -947,7 +959,7 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	if !strings.HasSuffix(q.Name, ".") {
 		q.Name += "."
 	}
-	cacheKey := fmt.Sprintf("%s:%d", strings.ToLower(q.Name), q.QType)
+	cacheKey := lowerName + ":" + strconv.Itoa(int(q.QType))
 
 	// Cache check (L1 + L2)
 	if cached := s.checkCache(ctx, request, cacheKey, clientIP, qTypeLabel, protocol, sendFn); cached != nil {
@@ -1202,12 +1214,7 @@ func (s *Server) checkCache(ctx context.Context, req *packet.DNSPacket, cacheKey
 			data[0] = byte(req.Header.ID >> 8)
 			data[1] = byte(req.Header.ID & 0xFF)
 		}
-		l1TTLCap := 300 * time.Second
-		if v := os.Getenv("REDIS_L1_TTL_CAP"); v != "" {
-			if secs, err := strconv.Atoi(v); err == nil && secs > 0 {
-				l1TTLCap = time.Duration(secs) * time.Second
-			}
-		}
+		l1TTLCap := s.l1TTLCap
 		if remainingTTL <= 0 {
 			remainingTTL = l1TTLCap
 		} else if remainingTTL > l1TTLCap {


### PR DESCRIPTION
## Summary
Four high-priority performance fixes in hot paths:

1. **Cache REDIS_L1_TTL_CAP at startup** (`server.go`)
   - Was calling `os.Getenv()` on every L2 cache hit
   - Now parsed once in `NewServer()` and stored in `s.l1TTLCap`

2. **Eliminate fmt.Sprintf in handlePacket** (`server.go:959`)
   - `fmt.Sprintf` is expensive in hottest path
   - Replaced with string concatenation: `lowerName + ":" + strconv.Itoa`

3. **Compute strings.ToLower once** (`server.go:949-952`)
   - Was calling `strings.ToLower(q.Name)` twice (CHAOS check + cacheKey)
   - Now computed once and reused

4. **Make recursive resolver root hints package-level constants** (`recursive.go`)
   - Was allocating new `[]string{13 elements}` on every recursive resolution
   - Now references package-level constants (no allocation per call)

## Test plan
- [x] `go build ./...` passes
- [x] `go test -timeout 5m ./internal/dns/server/` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized DNS server performance through more efficient resolver initialization and cache handling, reducing memory allocations and redundant environment variable reads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/cloudDNS/pull/268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->