### PR TITLE
perf(medium): eliminate string allocations in hot paths

### DIFF
--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -817,7 +817,7 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 	case TXT:
 		if err := buffer.Writeu16(uint16(len(r.Txt) + 1)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Write(byte(len(r.Txt))); err != nil { return 0, err } // #nosec G115
-		if err := buffer.WriteRange(buffer.Position(), []byte(r.Txt)); err != nil { return 0, err }
+		if err := buffer.WriteStringRange(buffer.Position(), r.Txt); err != nil { return 0, err }
 	case SOA:
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }
@@ -835,9 +835,9 @@ func (r *DNSRecord) Write(buffer *BytePacketBuffer) (int, error) {
 	case HINFO:
 		if err := buffer.Writeu16(uint16(len(r.CPU) + len(r.OS) + 2)); err != nil { return 0, err } // #nosec G115
 		if err := buffer.Write(byte(len(r.CPU))); err != nil { return 0, err } // #nosec G115
-		if err := buffer.WriteRange(buffer.Position(), []byte(r.CPU)); err != nil { return 0, err }
+		if err := buffer.WriteStringRange(buffer.Position(), r.CPU); err != nil { return 0, err }
 		if err := buffer.Write(byte(len(r.OS))); err != nil { return 0, err } // #nosec G115
-		if err := buffer.WriteRange(buffer.Position(), []byte(r.OS)); err != nil { return 0, err }
+		if err := buffer.WriteStringRange(buffer.Position(), r.OS); err != nil { return 0, err }
 	case MINFO:
 		lenPos := buffer.Position()
 		if err := buffer.Writeu16(0); err != nil { return 0, err }

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -2019,13 +2019,15 @@ func (s *Server) validateDNSSEC(ctx context.Context, zoneName string, response *
 	rrsigGroups := make(map[string][]packet.DNSRecord)
 	for _, rec := range response.Answers {
 		if rec.Type == packet.RRSIG {
-			key := fmt.Sprintf("%s:%d", strings.ToLower(rec.Name), rec.TypeCovered)
+			lowerName := strings.ToLower(rec.Name)
+			key := lowerName + ":" + strconv.Itoa(int(rec.TypeCovered))
 			rrsigGroups[key] = append(rrsigGroups[key], rec)
 		}
 	}
 	for _, rec := range response.Authorities {
 		if rec.Type == packet.RRSIG {
-			key := fmt.Sprintf("%s:%d", strings.ToLower(rec.Name), rec.TypeCovered)
+			lowerName := strings.ToLower(rec.Name)
+			key := lowerName + ":" + strconv.Itoa(int(rec.TypeCovered))
 			rrsigGroups[key] = append(rrsigGroups[key], rec)
 		}
 	}
@@ -2303,7 +2305,8 @@ func (s *Server) groupRecords(records []packet.DNSRecord) [][]packet.DNSRecord {
 		if r.Type == packet.RRSIG || r.Type == packet.OPT || r.Type == packet.TSIG {
 			continue
 		}
-		key := fmt.Sprintf("%s:%d", strings.ToLower(r.Name), r.Type)
+		lowerName := strings.ToLower(r.Name)
+		key := lowerName + ":" + strconv.Itoa(int(r.Type))
 		if _, ok := groups[key]; !ok {
 			keys = append(keys, key)
 		}


### PR DESCRIPTION
## Summary
Medium-priority performance optimizations targeting string allocations:

1. **Use WriteStringRange instead of WriteRange+[]byte** (`packet.go`)
   - TXT, HINFO record writing now uses `WriteStringRange` instead of `WriteRange` with `[]byte(string)`
   - Eliminates the []byte allocation and copy when writing string fields

2. **Replace fmt.Sprintf with string concatenation** (`server.go`)
   - RRSIG grouping in `validateDNSSECChain`: 2 locations
   - `groupRecords` function: 1 location
   - fmt.Sprintf is ~3x slower than string concatenation

## Test plan
- [x] `go build ./...` passes
- [x] `go test -timeout 5m ./internal/dns/server/` passes
- [x] `go test -timeout 5m ./internal/dns/packet/` passes