### PR TITLE
fix: add s.done shutdown handling to goroutine workers

### DIFF
--- a/internal/dns/server/cache_hammer_test.go
+++ b/internal/dns/server/cache_hammer_test.go
@@ -33,7 +33,7 @@ func TestCache_ConcurrencyHammer(t *testing.T) {
 	defer cancel()
 
 	// Start invalidation listener
-	go srv.startInvalidationListener(ctx)
+	go srv.startInvalidationListener(ctx, make(chan struct{}))
 	// Give it a moment to subscribe
 	time.Sleep(100 * time.Millisecond)
 

--- a/internal/dns/server/cache_integration_test.go
+++ b/internal/dns/server/cache_integration_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -73,4 +74,43 @@ func TestCacheInvalidation_MalformedPayload(t *testing.T) {
 	
 	// Server should just log a warning and not crash
 	time.Sleep(100 * time.Millisecond)
+}
+
+func TestCacheInvalidation_ListenerDoneSignal(t *testing.T) {
+	mr, _ := miniredis.Run()
+	defer mr.Close()
+
+	srv := NewServer("127.0.0.1:0", nil, nil)
+	srv.Redis = NewRedisCache(mr.Addr(), "", 0, RedisPoolConfig{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		srv.startInvalidationListener(ctx, done)
+	}()
+
+	// Give it a moment to subscribe
+	time.Sleep(100 * time.Millisecond)
+
+	// Close done - should trigger exit via case <-done:
+	close(done)
+
+	// Wait for goroutine to exit
+	wgDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+
+	select {
+	case <-wgDone:
+		// Pass - exited via done signal
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("startInvalidationListener did not exit within 500ms after done close")
+	}
 }

--- a/internal/dns/server/cache_integration_test.go
+++ b/internal/dns/server/cache_integration_test.go
@@ -28,7 +28,7 @@ func TestCacheInvalidation_Integration(t *testing.T) {
 	defer cancel()
 
 	// 3. Start the invalidation listener in a goroutine
-	go srv.startInvalidationListener(ctx)
+	go srv.startInvalidationListener(ctx, make(chan struct{}))
 	
 	// Give it a moment to subscribe
 	time.Sleep(100 * time.Millisecond)
@@ -65,7 +65,7 @@ func TestCacheInvalidation_MalformedPayload(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go srv.startInvalidationListener(ctx)
+	go srv.startInvalidationListener(ctx, make(chan struct{}))
 	time.Sleep(100 * time.Millisecond)
 
 	// Publish malformed payload directly to channel

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -305,7 +305,7 @@ func (s *Server) updateDNSSECMetrics(ctx context.Context) {
 }
 
 // startInvalidationListener listens for cache invalidation events from Redis pub/sub.
-func (s *Server) startInvalidationListener(ctx context.Context) {
+func (s *Server) startInvalidationListener(ctx context.Context, done <-chan struct{}) {
 	pubsub := s.Redis.Subscribe(ctx)
 	defer func() {
 		if errClose := pubsub.Close(); errClose != nil {
@@ -318,6 +318,9 @@ func (s *Server) startInvalidationListener(ctx context.Context) {
 
 	for {
 		select {
+		case <-done:
+			s.Logger.Info("stopping global cache invalidation listener via done")
+			return
 		case <-ctx.Done():
 			s.Logger.Info("stopping global cache invalidation listener")
 			return
@@ -357,7 +360,7 @@ func (s *Server) startInvalidationListener(ctx context.Context) {
 
 // dlqRetryWorker processes messages from the dead letter queue with retry logic.
 // It runs until the context is canceled.
-func (s *Server) dlqRetryWorker(ctx context.Context) {
+func (s *Server) dlqRetryWorker(ctx context.Context, done <-chan struct{}) {
 	s.Logger.Info("starting DLQ retry worker")
 
 	ticker := time.NewTicker(5 * time.Second)
@@ -365,6 +368,9 @@ func (s *Server) dlqRetryWorker(ctx context.Context) {
 
 	for {
 		select {
+		case <-done:
+			s.Logger.Info("stopping DLQ retry worker via done")
+			return
 		case <-ctx.Done():
 			s.Logger.Info("stopping DLQ retry worker")
 			return
@@ -491,14 +497,14 @@ func (s *Server) Run(ctx context.Context) error {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			s.startInvalidationListener(ctx)
+			s.startInvalidationListener(ctx, s.done)
 		}()
 
 		// Start DLQ retry worker
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
-			s.dlqRetryWorker(ctx)
+			s.dlqRetryWorker(ctx, s.done)
 		}()
 	}
 

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -1437,22 +1437,23 @@ func TestDLQRetryWorker_Shutdown(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
+	done := make(chan struct{})
 	go func() {
 		defer wg.Done()
-		srv.dlqRetryWorker(ctx)
+		srv.dlqRetryWorker(ctx, done)
 	}()
 
 	// Cancel immediately — worker should exit promptly, not after 5s
 	cancel()
 
-	done := make(chan struct{})
+	wgDone := make(chan struct{})
 	go func() {
 		wg.Wait()
-		close(done)
+		close(wgDone)
 	}()
 
 	select {
-	case <-done:
+	case <-wgDone:
 		// Pass — exited promptly after context cancel
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("dlqRetryWorker did not exit within 500ms after context cancel")


### PR DESCRIPTION
## Summary
- Add `s.done` shutdown signal handling to `startInvalidationListener` and `dlqRetryWorker`
- Both workers now properly exit when `s.done` is closed during graceful shutdown
- Follows the established pattern used by `udpWorker`, `cleanupLoop`, and `CleanupLoop`
- Fixes goroutine leaks when these workers get stuck in blocking Redis operations

## Changes
- Modified function signatures to accept `done <-chan struct{}` parameter
- Added `case <-done:` to select statements before `ctx.Done()`
- Updated all call sites and tests to pass `s.done` channel

## Test Plan
- [x] `go test -v -run TestDLQRetryWorker ./internal/dns/server/` - PASS
- [x] `go test -short -timeout 5m ./...` - all tests PASS

Fixes #219, #220