### PR TITLE
Add tenant authorization to AXFR/IXFR handlers

### DIFF
--- a/internal/dns/server/rfc2136_test.go
+++ b/internal/dns/server/rfc2136_test.go
@@ -266,7 +266,9 @@ func TestHandleUpdateTSIG(t *testing.T) {
 		},
 	}
 	srv := NewServer("127.0.0.1:0", repo, nil)
-	srv.TsigKeys["testkey."] = []byte("secret123")
+	srv.TsigKeys = map[string]TsigKey{
+		"testkey.": {Secret: []byte("secret123"), TenantID: ""},
+	}
 
 	req := packet.NewDNSPacket()
 	req.Header.Opcode = packet.OpcodeUpdate
@@ -325,7 +327,7 @@ func TestHandleUpdate_ErrorCases(t *testing.T) {
 		zones: []domain.Zone{{ID: "z1", Name: "error.test."}},
 	}
 	srv := NewServer("127.0.0.1:0", repo, nil)
-	srv.TsigKeys["key1"] = []byte("secret")
+	srv.TsigKeys["key1"] = TsigKey{Secret: []byte("secret"), TenantID: ""}
 
 	// 1. Invalid ZOCOUNT != 1
 	req := packet.NewDNSPacket()

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -70,6 +70,12 @@ func (t *cacheLockTable) lockKey(key string) *cacheLockShard {
 	return &t[fnv32(key)%cacheLockShardCount]
 }
 
+// TsigKey holds a TSIG key's secret and authorized tenant ID.
+type TsigKey struct {
+	Secret   []byte
+	TenantID string
+}
+
 // Server is the core DNS server that handles incoming queries,
 // zone transfers (AXFR/IXFR), updates (RFC 2136), and NOTIFY (RFC 1996).
 type Server struct {
@@ -87,7 +93,7 @@ type Server struct {
 	Logger           *slog.Logger
 	queryFn          func(server string, name string, qtype packet.QueryType) (*packet.DNSPacket, error)
 	limiter          *rateLimiter
-	TsigKeys         map[string][]byte
+	TsigKeys         map[string]TsigKey
 	NodeID           string
 	RecursionEnabled bool
 	CookieSecret     []byte
@@ -161,7 +167,7 @@ func NewServer(addr string, repo ports.DNSRepository, logger *slog.Logger) *Serv
 		udpQueue:         make(chan udpTask, 50000),
 		Logger:           logger,
 		limiter:          newRateLimiter(500000, 200000, 1000000),
-		TsigKeys:         make(map[string][]byte),
+		TsigKeys:         make(map[string]TsigKey),
 		NodeID:           nodeID,
 		RecursionEnabled: recursion,
 		CookieSecret:     make([]byte, 32),
@@ -785,29 +791,56 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}
-		secret, ok := s.TsigKeys[tsig.Name]
+		key, ok := s.TsigKeys[tsig.Name]
 		if !ok {
 			s.Logger.Debug("AXFR failed: unknown TSIG key", "key", tsig.Name, "zone", q.Name)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}
-		if errVerify := request.VerifyTSIG(rawData, request.TSIGStart, secret); errVerify != nil {
+		if errVerify := request.VerifyTSIG(rawData, request.TSIGStart, key.Secret); errVerify != nil {
 			s.Logger.Warn("AXFR failed: TSIG verification failed", "error", errVerify, "zone", q.Name)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}
 	}
 
-	zone, err := s.Repo.GetZone(ctx, q.Name)
-	if err != nil {
-		s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
-		s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
-		return
-	}
-	if zone == nil {
-		s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
-		s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
-		return
+	// Lookup zone (needed regardless of TSIG for AXFR streaming)
+	var zone *domain.Zone
+	var err error
+	if request.TSIGStart != -1 && len(request.Resources) > 0 {
+		tsig := request.Resources[len(request.Resources)-1]
+		key := s.TsigKeys[tsig.Name]
+
+		zone, err = s.Repo.GetZone(ctx, q.Name)
+		if err != nil {
+			s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
+			s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
+			return
+		}
+		if zone == nil {
+			s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
+			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
+			return
+		}
+
+		// Issue #256: tenant authorization check
+		if key.TenantID != "" && key.TenantID != zone.TenantID {
+			s.Logger.Warn("AXFR rejected: tenant mismatch", "key", tsig.Name, "zone", q.Name, "zone_tenant", zone.TenantID, "key_tenant", key.TenantID)
+			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
+			return
+		}
+	} else {
+		zone, err = s.Repo.GetZone(ctx, q.Name)
+		if err != nil {
+			s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
+			s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
+			return
+		}
+		if zone == nil {
+			s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
+			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
+			return
+		}
 	}
 
 	iter, errIter := s.Repo.ListRecordsForZoneStreaming(ctx, zone.ID, zone.TenantID)
@@ -1636,13 +1669,13 @@ func (s *Server) handleUpdate(ctx context.Context, request *packet.DNSPacket, ra
 			response.Header.ResCode = packet.RcodeNotAuth
 			return s.sendUpdateResponse(response, sendFn)
 		}
-		secret, ok := s.TsigKeys[tsig.Name]
+		key, ok := s.TsigKeys[tsig.Name]
 		if !ok {
 			s.Logger.Debug("update failed: unknown TSIG key", "key", tsig.Name)
 			response.Header.ResCode = packet.RcodeNotAuth
 			return s.sendUpdateResponse(response, sendFn)
 		}
-		if errVerify := request.VerifyTSIG(rawData, request.TSIGStart, secret); errVerify != nil {
+		if errVerify := request.VerifyTSIG(rawData, request.TSIGStart, key.Secret); errVerify != nil {
 			s.Logger.Warn("update failed: TSIG verification failed", "error", errVerify)
 			response.Header.ResCode = packet.RcodeNotAuth
 			return s.sendUpdateResponse(response, sendFn)
@@ -1667,6 +1700,17 @@ func (s *Server) handleUpdate(ctx context.Context, request *packet.DNSPacket, ra
 		s.Logger.Warn("update failed: not authoritative for zone", "zone", zone.Name)
 		response.Header.ResCode = packet.RcodeNotAuth
 		return s.sendUpdateResponse(response, sendFn)
+	}
+
+	// Issue #256: tenant authorization check for TSIG-authenticated updates
+	if request.TSIGStart != -1 && len(request.Resources) > 0 {
+		tsig := request.Resources[len(request.Resources)-1]
+		key := s.TsigKeys[tsig.Name]
+		if key.TenantID != "" && key.TenantID != dbZone.TenantID {
+			s.Logger.Warn("update rejected: tenant mismatch", "key", tsig.Name, "zone", zone.Name, "zone_tenant", dbZone.TenantID, "key_tenant", key.TenantID)
+			response.Header.ResCode = packet.RcodeNotAuth
+			return s.sendUpdateResponse(response, sendFn)
+		}
 	}
 
 	// 2. Prerequisite Checks (PRCOUNT)
@@ -1758,13 +1802,13 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}
-		secret, ok := s.TsigKeys[tsig.Name]
+		key, ok := s.TsigKeys[tsig.Name]
 		if !ok {
 			s.Logger.Debug("IXFR failed: unknown TSIG key", "key", tsig.Name, "zone", q.Name)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
 		}
-		if errVerify := request.VerifyTSIG(rawData, request.TSIGStart, secret); errVerify != nil {
+		if errVerify := request.VerifyTSIG(rawData, request.TSIGStart, key.Secret); errVerify != nil {
 			s.Logger.Warn("IXFR failed: TSIG verification failed", "error", errVerify, "zone", q.Name)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
 			return
@@ -1780,11 +1824,33 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 	clientSOA := request.Authorities[0]
 	clientSerial := clientSOA.Serial
 
-	zone, err := s.Repo.GetZone(ctx, q.Name)
-	if err != nil || zone == nil {
-		s.Logger.Warn("IXFR requested for non-existent zone", "name", q.Name, "error", err)
-		s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
-		return
+	// Lookup zone (needed regardless of TSIG for IXFR)
+	var zone *domain.Zone
+	var err error
+	if request.TSIGStart != -1 && len(request.Resources) > 0 {
+		tsig := request.Resources[len(request.Resources)-1]
+		key := s.TsigKeys[tsig.Name]
+
+		zone, err = s.Repo.GetZone(ctx, q.Name)
+		if err != nil || zone == nil {
+			s.Logger.Warn("IXFR requested for non-existent zone", "name", q.Name, "error", err)
+			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
+			return
+		}
+
+		// Issue #259: tenant authorization check
+		if key.TenantID != "" && key.TenantID != zone.TenantID {
+			s.Logger.Warn("IXFR rejected: tenant mismatch", "key", tsig.Name, "zone", q.Name, "zone_tenant", zone.TenantID, "key_tenant", key.TenantID)
+			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
+			return
+		}
+	} else {
+		zone, err = s.Repo.GetZone(ctx, q.Name)
+		if err != nil || zone == nil {
+			s.Logger.Warn("IXFR requested for non-existent zone", "name", q.Name, "error", err)
+			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
+			return
+		}
 	}
 
 	// Get current SOA

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -805,40 +805,25 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 	}
 
 	// Lookup zone (needed regardless of TSIG for AXFR streaming)
-	var zone *domain.Zone
-	var err error
+	zone, err := s.Repo.GetZone(ctx, q.Name)
+	if err != nil {
+		s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
+		s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
+		return
+	}
+	if zone == nil {
+		s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
+		s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
+		return
+	}
+
+	// Issue #256: tenant authorization check for TSIG-authenticated requests
 	if request.TSIGStart != -1 && len(request.Resources) > 0 {
 		tsig := request.Resources[len(request.Resources)-1]
 		key := s.TsigKeys[tsig.Name]
-
-		zone, err = s.Repo.GetZone(ctx, q.Name)
-		if err != nil {
-			s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
-			s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
-			return
-		}
-		if zone == nil {
-			s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
-			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
-			return
-		}
-
-		// Issue #256: tenant authorization check
 		if key.TenantID != "" && key.TenantID != zone.TenantID {
 			s.Logger.Warn("AXFR rejected: tenant mismatch", "key", tsig.Name, "zone", q.Name, "zone_tenant", zone.TenantID, "key_tenant", key.TenantID)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
-			return
-		}
-	} else {
-		zone, err = s.Repo.GetZone(ctx, q.Name)
-		if err != nil {
-			s.Logger.Error("AXFR failed to look up zone", "zone", q.Name, "error", err)
-			s.sendTCPError(conn, request.Header.ID, 2) // SERVFAIL
-			return
-		}
-		if zone == nil {
-			s.Logger.Warn("AXFR requested for non-existent zone", "name", q.Name)
-			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
 			return
 		}
 	}
@@ -1825,30 +1810,20 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 	clientSerial := clientSOA.Serial
 
 	// Lookup zone (needed regardless of TSIG for IXFR)
-	var zone *domain.Zone
-	var err error
+	zone, err := s.Repo.GetZone(ctx, q.Name)
+	if err != nil || zone == nil {
+		s.Logger.Warn("IXFR requested for non-existent zone", "name", q.Name, "error", err)
+		s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
+		return
+	}
+
+	// Issue #259: tenant authorization check for TSIG-authenticated requests
 	if request.TSIGStart != -1 && len(request.Resources) > 0 {
 		tsig := request.Resources[len(request.Resources)-1]
 		key := s.TsigKeys[tsig.Name]
-
-		zone, err = s.Repo.GetZone(ctx, q.Name)
-		if err != nil || zone == nil {
-			s.Logger.Warn("IXFR requested for non-existent zone", "name", q.Name, "error", err)
-			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
-			return
-		}
-
-		// Issue #259: tenant authorization check
 		if key.TenantID != "" && key.TenantID != zone.TenantID {
 			s.Logger.Warn("IXFR rejected: tenant mismatch", "key", tsig.Name, "zone", q.Name, "zone_tenant", zone.TenantID, "key_tenant", key.TenantID)
 			s.sendTCPError(conn, request.Header.ID, 5) // NotAuth
-			return
-		}
-	} else {
-		zone, err = s.Repo.GetZone(ctx, q.Name)
-		if err != nil || zone == nil {
-			s.Logger.Warn("IXFR requested for non-existent zone", "name", q.Name, "error", err)
-			s.sendTCPError(conn, request.Header.ID, 3) // NXDOMAIN
 			return
 		}
 	}

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -1295,6 +1295,42 @@ func TestHandleAXFR_TSIGVerifyFailed(t *testing.T) {
 	}
 }
 
+func TestHandleAXFR_TenantMismatch(t *testing.T) {
+	repo := &mockServerRepo{
+		zones: []domain.Zone{{ID: "z1", Name: "tsig.test.", TenantID: "tenant-a"}},
+		records: []domain.Record{
+			{ZoneID: "z1", Name: "tsig.test.", Type: domain.TypeSOA, Content: "ns1. ns2. 1 2 3 4 5"},
+		},
+	}
+	srv := NewServer(":0", repo, nil)
+	srv.TsigKeys = map[string]TsigKey{
+		"real-key.": {Secret: []byte("secret"), TenantID: "tenant-b"}, // different tenant
+	}
+
+	req := packet.NewDNSPacket()
+	req.Header.ID = 1234
+	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "tsig.test.", QType: packet.AXFR})
+
+	buf := packet.NewBytePacketBuffer()
+	_ = req.Write(buf)
+	_ = req.SignTSIG(buf, "real-key.", []byte("secret"))
+
+	conn := &mockTCPConn{}
+	srv.handleAXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
+
+	if len(conn.captured) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
+	}
+
+	res := packet.NewDNSPacket()
+	pb := packet.NewBytePacketBuffer()
+	pb.Load(conn.captured[0])
+	_ = res.FromBuffer(pb)
+	if res.Header.ResCode != packet.RcodeRefused {
+		t.Errorf("Expected Refused (5), got %d", res.Header.ResCode)
+	}
+}
+
 func TestServer_Run_NonBlockingOnTCPDoTFailure(t *testing.T) {
 	t.Setenv("DOH_PORT", "10443")
 	// Bind to a port first to force TCP error in Run

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -1227,8 +1227,8 @@ func TestHandleAXFR_TSIGUnknownKey(t *testing.T) {
 		},
 	}
 	srv := NewServer(":0", repo, nil)
-	srv.TsigKeys = map[string][]byte{
-		"real-key.": []byte("secret"),
+	srv.TsigKeys = map[string]TsigKey{
+		"real-key.": {Secret: []byte("secret"), TenantID: ""},
 	}
 
 	req := packet.NewDNSPacket()
@@ -1263,8 +1263,8 @@ func TestHandleAXFR_TSIGVerifyFailed(t *testing.T) {
 		},
 	}
 	srv := NewServer(":0", repo, nil)
-	srv.TsigKeys = map[string][]byte{
-		"real-key.": []byte("secret"),
+	srv.TsigKeys = map[string]TsigKey{
+		"real-key.": {Secret: []byte("secret"), TenantID: ""},
 	}
 
 	req := packet.NewDNSPacket()
@@ -1339,8 +1339,8 @@ func TestHandleIXFR_TSIGUnknownKey(t *testing.T) {
 		},
 	}
 	srv := NewServer(":0", repo, nil)
-	srv.TsigKeys = map[string][]byte{
-		"real-key.": []byte("secret"),
+	srv.TsigKeys = map[string]TsigKey{
+		"real-key.": {Secret: []byte("secret"), TenantID: ""},
 	}
 
 	req := packet.NewDNSPacket()
@@ -1380,8 +1380,8 @@ func TestHandleIXFR_TSIGVerifyFailed(t *testing.T) {
 		},
 	}
 	srv := NewServer(":0", repo, nil)
-	srv.TsigKeys = map[string][]byte{
-		"real-key.": []byte("secret"),
+	srv.TsigKeys = map[string]TsigKey{
+		"real-key.": {Secret: []byte("secret"), TenantID: ""},
 	}
 
 	req := packet.NewDNSPacket()


### PR DESCRIPTION
## Summary
- Add `TsigKey` struct with `Secret` and `TenantID` fields - replaces `map[string][]byte`
- Add tenant authorization checks in `handleAXFR`, `handleUpdate`, and `handleIXFR`
- Issues #256 (AXFR zone enumeration - no tenant authorization check) and #259 (IXFR fallback missing authorization re-check) are now fixed
- Tenant check occurs after zone lookup, verifying key.TenantID matches zone.TenantID before streaming records

## Changes
- **internal/dns/server/server.go**: TsigKey struct, refactored handlers with tenant checks
- **internal/dns/server/server_test.go**: Updated test keys to new struct, added tenant mismatch test

## Test plan
- [x] `go test -short -timeout 5m ./...` passes

## Related Issues
Fixes #256
Fixes #259