### PR TITLE
Fix SOA serial overflow in IXFR handler

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1888,12 +1888,18 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 		return
 	}
 
-	var currentSerial uint32
-	if _, err := fmt.Sscanf(fields[2], "%d", &currentSerial); err != nil {
+	var serial64 uint64
+	if _, err := fmt.Sscanf(fields[2], "%d", &serial64); err != nil {
 		s.Logger.Error("IXFR failed: invalid SOA serial", "zone", zone.Name, "serial", fields[2], "error", err)
 		s.sendTCPError(conn, request.Header.ID, 2)
 		return
 	}
+	if serial64 > math.MaxUint32 {
+		s.Logger.Error("IXFR failed: SOA serial exceeds uint32 max", "zone", zone.Name, "serial", fields[2])
+		s.sendTCPError(conn, request.Header.ID, 2)
+		return
+	}
+	currentSerial := uint32(serial64)
 
 	if clientSerial == currentSerial {
 		// Client is up to date, just send current SOA


### PR DESCRIPTION
## Summary
- Fix issue #262: SOA serial parsing could panic on malformed content - uint32 overflow
- Parse SOA serial into `uint64` first, then validate value fits in `uint32` before casting
- Reject malformed SOA with SERVFAIL if value exceeds uint32 max

## Problem
`fmt.Sscanf(fields[2], "%d", &currentSerial)` with `uint32` destination could wrap or error on oversized values. Behavior was undefined.

## Solution
Parse into `uint64` first, check `serial64 > math.MaxUint32`, then cast to `uint32`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short -timeout 5m ./...` passes

## Related Issues
Fixes #262