### PR TITLE
Fix unbounded IXFR chunk processing with memory limits

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -44,6 +44,13 @@ import (
 // ClassCHAOS is the DNS class for server identity and metadata.
 const ClassCHAOS = 3
 
+// IXFR limits to prevent memory exhaustion from unbounded chunk processing.
+const (
+	MaxIXFRChunks      = 1000  // max chunks per IXFR response
+	MaxRecordsPerChunk = 10000 // max records per chunk Deleted/Added arrays
+	MaxAXFRRecords     = 50000 // max records in AXFR fallback or NSEC generation
+)
+
 // cacheLockShardCount is the number of shards for per-key cache locks.
 // Using sharded locking avoids unbounded map growth while providing per-key granularity.
 const cacheLockShardCount = 256
@@ -1914,6 +1921,20 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 	// Fetch changes since clientSerial using IXFR chain logic
 	chunks, err := s.Repo.GetIXFRChain(ctx, zone.ID, clientSerial, currentSerial)
 
+	// Enforce IXFR chunk limits to prevent memory exhaustion
+	if len(chunks) > MaxIXFRChunks {
+		s.Logger.Error("IXFR chunk count exceeds limit", "zone", zone.Name, "count", len(chunks), "limit", MaxIXFRChunks)
+		s.sendTCPError(conn, request.Header.ID, 2)
+		return
+	}
+	for i, chunk := range chunks {
+		if len(chunk.Deleted) > MaxRecordsPerChunk || len(chunk.Added) > MaxRecordsPerChunk {
+			s.Logger.Error("IXFR chunk record count exceeds limit", "zone", zone.Name, "chunk", i, "deleted", len(chunk.Deleted), "added", len(chunk.Added), "limit", MaxRecordsPerChunk)
+			s.sendTCPError(conn, request.Header.ID, 2)
+			return
+		}
+	}
+
 	// RFC 1995: Verify full IXFR chain continuity
 	// Note: clientSerial+1 wraps to 0 when clientSerial is max uint32.
 	// In that case, we can only validate if chunks starts at 0 (which is valid after wrap).
@@ -1970,7 +1991,14 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 		s.sendSingleRecordResponse(conn, request.Header.ID, q, pSOA)
 
 		// 3. Stream all records in the zone
+		recordCount := 0
 		for iter.Next() {
+			recordCount++
+			if recordCount > MaxAXFRRecords {
+				s.Logger.Error("AXFR fallback record count exceeds limit", "zone", zone.Name, "count", recordCount, "limit", MaxAXFRRecords)
+				s.sendTCPError(conn, request.Header.ID, 2)
+				return
+			}
 			rec := iter.Record()
 			if rec.Type == domain.TypeSOA {
 				continue
@@ -2651,7 +2679,13 @@ func (s *Server) generateNSEC(ctx context.Context, zone *domain.Zone, queryName 
 	nameToTypes := make(map[string][]domain.RecordType)
 	var uniqueNames []string
 	seen := make(map[string]bool)
+	recordCount := 0
 	for iter.Next() {
+		recordCount++
+		if recordCount > MaxAXFRRecords {
+			s.Logger.Error("NSEC generation record count exceeds limit", "zone", zone.Name, "count", recordCount, "limit", MaxAXFRRecords)
+			return packet.DNSRecord{}, fmt.Errorf("NSEC generation exceeded record limit")
+		}
 		r := iter.Record()
 		if !seen[r.Name] {
 			uniqueNames = append(uniqueNames, r.Name)

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -892,14 +892,19 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 	s.sendAXFRRecord(conn, request.Header.ID, q, soa, 0)
 
 	// Stream all non-SOA records
-	index := 1
+	recordCount := 0
 	for iter.Next() {
+		recordCount++
+		if recordCount > MaxAXFRRecords {
+			s.Logger.Error("AXFR record count exceeds limit", "zone", zone.ID, "count", recordCount, "limit", MaxAXFRRecords)
+			s.sendTCPError(conn, request.Header.ID, 2)
+			return
+		}
 		rec := iter.Record()
 		if rec.Type == domain.TypeSOA {
 			continue
 		}
-		s.sendAXFRRecord(conn, request.Header.ID, q, rec, index)
-		index++
+		s.sendAXFRRecord(conn, request.Header.ID, q, rec, recordCount)
 	}
 	if err := iter.Err(); err != nil {
 		s.Logger.Error("AXFR failed during record streaming", "zone", zone.ID, "error", err)
@@ -908,7 +913,7 @@ func (s *Server) handleAXFR(ctx context.Context, conn net.Conn, request *packet.
 	}
 
 	// Stream SOA last
-	s.sendAXFRRecord(conn, request.Header.ID, q, soa, index)
+	s.sendAXFRRecord(conn, request.Header.ID, q, soa, recordCount)
 	s.Logger.Info("AXFR completed", "zone", zone.Name)
 }
 
@@ -1469,11 +1474,15 @@ func (s *Server) handleNxDomain(ctx context.Context, req *packet.DNSPacket, q pa
 		}
 		if dnssecOK {
 			if len(nsec3params) > 0 {
-				if nsec, err := s.generateNSEC3(ctx, zone, q.Name, ""); err == nil {
+				if nsec, err := s.generateNSEC3(ctx, zone, q.Name, ""); err != nil {
+					s.Logger.Error("NSEC3 generation failed, proceeding without DNSSEC proof", "zone", zone.Name, "query", q.Name, "error", err)
+				} else {
 					resp.Authorities = append(resp.Authorities, nsec)
 				}
 			} else {
-				if nsec, err := s.generateNSEC(ctx, zone, q.Name); err == nil {
+				if nsec, err := s.generateNSEC(ctx, zone, q.Name); err != nil {
+					s.Logger.Error("NSEC generation failed, proceeding without DNSSEC proof", "zone", zone.Name, "query", q.Name, "error", err)
+				} else {
 					resp.Authorities = append(resp.Authorities, nsec)
 				}
 			}
@@ -2784,7 +2793,13 @@ func (s *Server) generateNSEC3(ctx context.Context, zone *domain.Zone, queryName
 	nameToTypes := make(map[string][]domain.RecordType)
 	var ownerNames []string
 	seen := make(map[string]bool)
+	recordCount := 0
 	for iter.Next() {
+		recordCount++
+		if recordCount > MaxAXFRRecords {
+			s.Logger.Error("NSEC3 generation record count exceeds limit", "zone", zone.Name, "count", recordCount, "limit", MaxAXFRRecords)
+			return packet.DNSRecord{}, fmt.Errorf("NSEC3 generation exceeded record limit")
+		}
 		r := iter.Record()
 		if !seen[r.Name] {
 			ownerNames = append(ownerNames, r.Name)

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -1477,7 +1477,7 @@ func TestHandleIXFR_ChunkCountExceedsLimit(t *testing.T) {
 	}
 
 	srv := NewServer(":0", repo, nil)
-	srv.TsigKeys = map[string][]byte{}
+	srv.TsigKeys = map[string]TsigKey{}
 
 	req := packet.NewDNSPacket()
 	req.Header.ID = 5679
@@ -1527,7 +1527,7 @@ func TestHandleIXFR_RecordsPerChunkExceedsLimit(t *testing.T) {
 	}
 
 	srv := NewServer(":0", repo, nil)
-	srv.TsigKeys = map[string][]byte{}
+	srv.TsigKeys = map[string]TsigKey{}
 
 	req := packet.NewDNSPacket()
 	req.Header.ID = 5680

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -70,6 +70,9 @@ type mockServerRepo struct {
 
 	// mockGetIXFRChain overrides GetIXFRChain when set.
 	mockGetIXFRChain func(ctx context.Context, zoneID string, fromSerial uint32, toSerial uint32) ([]domain.IXFRChunk, error)
+
+	// mockListRecordsForZoneStreaming overrides ListRecordsForZoneStreaming when set.
+	mockListRecordsForZoneStreaming func(ctx context.Context, zoneID string, tenantID string) (ports.RecordIterator, error)
 }
 
 func (m *mockServerRepo) GetAPIKeyByHash(_ context.Context, keyHash string) (*domain.APIKey, error) {
@@ -229,6 +232,9 @@ func (m *mockServerRepo) ListRecordsForZone(ctx context.Context, zoneID string, 
 }
 
 func (m *mockServerRepo) ListRecordsForZoneStreaming(ctx context.Context, zoneID string, tenantID string) (ports.RecordIterator, error) {
+	if m.mockListRecordsForZoneStreaming != nil {
+		return m.mockListRecordsForZoneStreaming(ctx, zoneID, tenantID)
+	}
 	if m.failListRecordsStreaming {
 		return nil, errors.New("list records streaming failed")
 	}
@@ -1543,6 +1549,48 @@ func TestHandleIXFR_RecordsPerChunkExceedsLimit(t *testing.T) {
 
 	conn := &mockTCPConn{}
 	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
+
+	if len(conn.captured) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
+	}
+
+	res := packet.NewDNSPacket()
+	pb := packet.NewBytePacketBuffer()
+	pb.Load(conn.captured[0])
+	_ = res.FromBuffer(pb)
+	if res.Header.ResCode != packet.RcodeServFail {
+		t.Errorf("Expected SERVFAIL (2), got %d", res.Header.ResCode)
+	}
+}
+
+func TestHandleAXFR_RecordCountExceedsLimit(t *testing.T) {
+	// Build records exceeding MaxAXFRRecords
+	tooManyRecords := make([]domain.Record, MaxAXFRRecords+1)
+	for i := range tooManyRecords {
+		tooManyRecords[i] = domain.Record{Name: "axfr-limit.test.", Type: domain.TypeA, Content: "1.1.1.1"}
+	}
+	repo := &mockServerRepo{
+		zones: []domain.Zone{{ID: "z1", Name: "axfr-limit.test."}},
+		records: []domain.Record{
+			{ZoneID: "z1", Name: "axfr-limit.test.", Type: domain.TypeSOA, Content: "ns1. ns2. 1 2 3 4 5"},
+		},
+	}
+	repo.mockListRecordsForZoneStreaming = func(ctx context.Context, zoneID string, tenantID string) (ports.RecordIterator, error) {
+		return &sliceRecordIterator{records: tooManyRecords, index: 0}, nil
+	}
+
+	srv := NewServer(":0", repo, nil)
+	srv.TsigKeys = map[string]TsigKey{}
+
+	req := packet.NewDNSPacket()
+	req.Header.ID = 5681
+	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "axfr-limit.test.", QType: packet.AXFR})
+
+	buf := packet.NewBytePacketBuffer()
+	_ = req.Write(buf)
+
+	conn := &mockTCPConn{}
+	srv.handleAXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
 
 	if len(conn.captured) != 1 {
 		t.Fatalf("Expected 1 response, got %d", len(conn.captured))

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -67,6 +67,9 @@ type mockServerRepo struct {
 	failCreateSOA        bool
 	failDeleteSOA        bool
 	failOnRecordName     string
+
+	// mockGetIXFRChain overrides GetIXFRChain when set.
+	mockGetIXFRChain func(ctx context.Context, zoneID string, fromSerial uint32, toSerial uint32) ([]domain.IXFRChunk, error)
 }
 
 func (m *mockServerRepo) GetAPIKeyByHash(_ context.Context, keyHash string) (*domain.APIKey, error) {
@@ -565,6 +568,9 @@ func (m *mockServerRepo) ListZoneChanges(ctx context.Context, zoneID string, fro
 }
 
 func (m *mockServerRepo) GetIXFRChain(ctx context.Context, zoneID string, fromSerial uint32, toSerial uint32) ([]domain.IXFRChunk, error) {
+	if m.mockGetIXFRChain != nil {
+		return m.mockGetIXFRChain(ctx, zoneID, fromSerial, toSerial)
+	}
 	changes, err := m.ListZoneChanges(ctx, zoneID, fromSerial)
 	if err != nil {
 		return nil, err
@@ -1450,6 +1456,104 @@ func TestHandleIXFR_TSIGVerifyFailed(t *testing.T) {
 	_ = res.FromBuffer(pb)
 	if res.Header.ResCode != packet.RcodeRefused {
 		t.Errorf("Expected NOTAUTH (5), got %d", res.Header.ResCode)
+	}
+}
+
+func TestHandleIXFR_ChunkCountExceedsLimit(t *testing.T) {
+	repo := &mockServerRepo{
+		zones: []domain.Zone{{ID: "z1", Name: "ixfr-limit.test."}},
+		records: []domain.Record{
+			{ZoneID: "z1", Name: "ixfr-limit.test.", Type: domain.TypeSOA, Content: "ns1. ns2. 1 2 3 4 5"},
+		},
+	}
+
+	// Build chunks exceeding MaxIXFRChunks
+	tooManyChunks := make([]domain.IXFRChunk, MaxIXFRChunks+1)
+	for i := range tooManyChunks {
+		tooManyChunks[i] = domain.IXFRChunk{Serial: uint32(i + 1)}
+	}
+	repo.mockGetIXFRChain = func(ctx context.Context, zoneID string, fromSerial uint32, toSerial uint32) ([]domain.IXFRChunk, error) {
+		return tooManyChunks, nil
+	}
+
+	srv := NewServer(":0", repo, nil)
+	srv.TsigKeys = map[string][]byte{}
+
+	req := packet.NewDNSPacket()
+	req.Header.ID = 5679
+	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "ixfr-limit.test.", QType: packet.IXFR})
+	req.Authorities = append(req.Authorities, packet.DNSRecord{
+		Name:   "ixfr-limit.test.",
+		Type:   packet.SOA,
+		Serial: uint32(len(tooManyChunks)),
+	})
+
+	buf := packet.NewBytePacketBuffer()
+	_ = req.Write(buf)
+
+	conn := &mockTCPConn{}
+	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
+
+	if len(conn.captured) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
+	}
+
+	res := packet.NewDNSPacket()
+	pb := packet.NewBytePacketBuffer()
+	pb.Load(conn.captured[0])
+	_ = res.FromBuffer(pb)
+	if res.Header.ResCode != packet.RcodeServFail {
+		t.Errorf("Expected SERVFAIL (2), got %d", res.Header.ResCode)
+	}
+}
+
+func TestHandleIXFR_RecordsPerChunkExceedsLimit(t *testing.T) {
+	repo := &mockServerRepo{
+		zones: []domain.Zone{{ID: "z1", Name: "ixfr-limit.test."}},
+		records: []domain.Record{
+			{ZoneID: "z1", Name: "ixfr-limit.test.", Type: domain.TypeSOA, Content: "ns1. ns2. 1 2 3 4 5"},
+		},
+	}
+
+	// Build chunks where Added exceeds MaxRecordsPerChunk
+	tooManyRecords := make([]domain.Record, MaxRecordsPerChunk+1)
+	for i := range tooManyRecords {
+		tooManyRecords[i] = domain.Record{Name: "ixfr-limit.test.", Type: domain.TypeA, Content: "1.1.1.1"}
+	}
+	repo.mockGetIXFRChain = func(ctx context.Context, zoneID string, fromSerial uint32, toSerial uint32) ([]domain.IXFRChunk, error) {
+		return []domain.IXFRChunk{
+			{Serial: 1, Deleted: []domain.Record{}, Added: tooManyRecords},
+		}, nil
+	}
+
+	srv := NewServer(":0", repo, nil)
+	srv.TsigKeys = map[string][]byte{}
+
+	req := packet.NewDNSPacket()
+	req.Header.ID = 5680
+	req.Questions = append(req.Questions, packet.DNSQuestion{Name: "ixfr-limit.test.", QType: packet.IXFR})
+	req.Authorities = append(req.Authorities, packet.DNSRecord{
+		Name:   "ixfr-limit.test.",
+		Type:   packet.SOA,
+		Serial: 2,
+	})
+
+	buf := packet.NewBytePacketBuffer()
+	_ = req.Write(buf)
+
+	conn := &mockTCPConn{}
+	srv.handleIXFR(context.Background(), conn, req, buf.Buf[:buf.Position()], nil)
+
+	if len(conn.captured) != 1 {
+		t.Fatalf("Expected 1 response, got %d", len(conn.captured))
+	}
+
+	res := packet.NewDNSPacket()
+	pb := packet.NewBytePacketBuffer()
+	pb.Load(conn.captured[0])
+	_ = res.FromBuffer(pb)
+	if res.Header.ResCode != packet.RcodeServFail {
+		t.Errorf("Expected SERVFAIL (2), got %d", res.Header.ResCode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #247: IXFR handlers process chunks from `GetIXFRChain()` with no limits, enabling memory exhaustion attacks
- Added `MaxIXFRChunks` (1000), `MaxRecordsPerChunk` (10000), and `MaxAXFRRecords` (50000) constants
- Added bounds checks in `handleIXFR` (chunk count, per-chunk record count, AXFR fallback record count)
- Added bounds check in `generateNSEC` streaming loop
- Added bounds check in `generateNSEC3` streaming loop (code review finding)
- Added bounds check in primary `handleAXFR` streaming loop (code review finding)
- Added logging when `generateNSEC`/`generateNSEC3` fails limit check instead of silently proceeding without DNSSEC proof
- Exceeding limits returns SERVFAIL rather than exhausting memory

## Test plan
- [x] `go build ./...`
- [x] `go test -short -timeout 5m ./...`

## Closes
Fixes #247