### PR TITLE
Fix UDP queue blocking send preventing graceful shutdown

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -538,7 +538,13 @@ func (s *Server) Run(ctx context.Context) error {
 					// Copy buffer since the backing array is reused across ReadFrom calls.
 					data := make([]byte, n)
 					copy(data, buf[:n])
-					s.udpQueue <- udpTask{addr: addr, data: data, conn: c}
+					// Non-blocking send: if queue is full, drop the packet rather than
+					// blocking (which would prevent graceful shutdown from being checked).
+					select {
+					case s.udpQueue <- udpTask{addr: addr, data: data, conn: c}:
+					default:
+						s.Logger.Warn("UDP queue full, dropping packet", "addr", addr)
+					}
 				}
 			}
 		}(conn)


### PR DESCRIPTION
## Summary
- Fixes #250: UDP listener goroutines blocked on `s.udpQueue` send when the channel buffer (50,000) was full
- While blocked, they could not re-check `s.done` for graceful shutdown — server would hang on shutdown
- Changed blocking send to non-blocking `select`+`default` that drops packets when queue is full
- Listener goroutine now always loops back promptly to re-check `s.done`

## Test plan
- [x] `go build ./...`
- [x] `go test -short -timeout 5m ./...`

## Closes
Fixes #250