### PR TITLE
Fix IXFR info disclosure: remove clientSerial from logs

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1838,7 +1838,7 @@ func (s *Server) handleIXFR(ctx context.Context, conn net.Conn, request *packet.
 		s.Logger.Warn("IXFR chain query failed, falling back to AXFR", "zone", zone.Name, "error", err)
 	} else if !historyValid {
 		s.Logger.Info("IXFR history gap detected, falling back to AXFR",
-			"zone", zone.Name, "client_serial", clientSerial)
+			"zone", zone.Name)
 
 		// RFC 1995: If IXFR is not possible, fall back to AXFR sequence using streaming
 		iter, errIter := s.Repo.ListRecordsForZoneStreaming(ctx, zone.ID, zone.TenantID)


### PR DESCRIPTION
## Summary
- Fixes #246: IXFR fallback to AXFR logged `client_serial` from the untrusted client request, enabling an attacker to probe and map the zone's change timeline
- Removed `client_serial` from the `Logger.Info` fallback message

## Test plan
- [x] `go build ./...`
- [x] `go test -short -timeout 5m ./...`

## Closes
Fixes #246