### PR TITLE
fix: graceful shutdown wg tracking for issues #245, #221, #220

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -416,6 +416,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		s.wg.Wait()  // Wait for all goroutines to finish before Run() returns
 		// Shutdown HTTP servers and Redis (can take time, so separate from wg wait)
+		//nolint:contextcheck // intentional: ctx is already cancelled at this point, need fresh background
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), s.shutdownTimeout())
 		defer shutdownCancel()
 		if s.dohServer != nil {

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -416,11 +416,10 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		s.wg.Wait()  // Wait for all goroutines to finish before Run() returns
 		// Shutdown HTTP servers and Redis (can take time, so separate from wg wait)
-		//nolint:contextcheck // intentional: ctx is already cancelled at this point, need fresh background
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), s.shutdownTimeout())
 		defer shutdownCancel()
 		if s.dohServer != nil {
-			if err := s.dohServer.Shutdown(shutdownCtx); err != nil {
+			if err := s.dohServer.Shutdown(shutdownCtx); err != nil { //nolint:contextcheck
 				s.Logger.Warn("failed to shut down DoH server", "error", err)
 			}
 		}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -409,16 +409,18 @@ func (s *Server) Run(ctx context.Context) error {
 				s.Logger.Warn("failed to close DoT listener", "error", err)
 			}
 		}
-		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, s.shutdownTimeout())
+		if s.doqListener != nil {
+			if err := s.doqListener.Close(); err != nil {
+				s.Logger.Warn("failed to close DoQ listener", "error", err)
+			}
+		}
+		s.wg.Wait()  // Wait for all goroutines to finish before Run() returns
+		// Shutdown HTTP servers and Redis (can take time, so separate from wg wait)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), s.shutdownTimeout())
 		defer shutdownCancel()
 		if s.dohServer != nil {
 			if err := s.dohServer.Shutdown(shutdownCtx); err != nil {
 				s.Logger.Warn("failed to shut down DoH server", "error", err)
-			}
-		}
-		if s.doqListener != nil {
-			if err := s.doqListener.Close(); err != nil {
-				s.Logger.Warn("failed to close DoQ listener", "error", err)
 			}
 		}
 		if s.Redis != nil {
@@ -628,7 +630,17 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	<-ctx.Done()
-	return nil // async shutdown handles cleanup in background
+	// Close listeners to unblock workers before wg.Wait() in defer
+	if s.tcpListener != nil {
+		_ = s.tcpListener.Close()
+	}
+	if s.dotListener != nil {
+		_ = s.dotListener.Close()
+	}
+	if s.doqListener != nil {
+		_ = s.doqListener.Close()
+	}
+	return nil
 }
 
 // handleDoH handles DNS-over-HTTPS requests (RFC 8484).

--- a/internal/dns/server/server_test.go
+++ b/internal/dns/server/server_test.go
@@ -998,7 +998,7 @@ func TestServer_Run_ContextCancel(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected nil error from Run on cancel, got %v", err)
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Fatal("srv.Run blocked for too long after context cancellation")
 	}
 }
@@ -1379,7 +1379,7 @@ func TestServer_Run_NonBlockingOnTCPDoTFailure(t *testing.T) {
 		if err != nil {
 			t.Logf("Run returned expected error: %v", err)
 		}
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(3 * time.Second):
 		t.Fatal("srv.Run blocked for too long")
 	}
 }

--- a/internal/dns/server/update.go
+++ b/internal/dns/server/update.go
@@ -41,7 +41,9 @@ func (s *Server) handleNotify(ctx context.Context, request *packet.DNSPacket, cl
 		if !isAuthorizedNotifier(clientIP, zone.MasterServer) {
 			s.Logger.Warn("NOTIFY rejected: unauthorized source", "from", clientIP, "master", zone.MasterServer)
 		} else if !s.DisableAsync {
+			s.wg.Add(1)
 			go func(zoneName string) {
+				defer s.wg.Done()
 				select {
 				case <-s.lifecycleCtx.Done():
 					return


### PR DESCRIPTION
## Summary
- **#245** (Critical): Add `s.wg.Wait()` to defer after `close(s.done)` so `Run()` blocks until all goroutines exit. Close listeners in the return path before `wg.Wait()` to unblock accept loops. Use `context.Background()` for shutdownCtx to avoid cancelled ctx.
- **#221** (Critical): Track NOTIFY handler goroutine with `s.wg.Add(1)/defer s.wg.Done()` so it is counted in the wait.
- **Bonus**: Close DoQ listener before `wg.Wait()` (was already closed in defer but needed before wait for proper ordering).
- **Tests**: Updated `TestServer_Run_ContextCancel` and `TestServer_Run_NonBlockingOnTCPDoTFailure` timeouts from 500ms to 3s to accommodate proper `wg.Wait()` behavior.

Note: Issue #220 (`dlqRetryWorker` ignoring `s.done`) was already fixed in main during the server.go refactoring.

Closes #245
Closes #221
Closes #220