### PR TITLE
feat: DNS64 support (RFC 6147)

### DIFF
--- a/docs/decisions/0012-dns64-support.md
+++ b/docs/decisions/0012-dns64-support.md
@@ -1,0 +1,67 @@
+# ADR 0012: DNS64 Support (RFC 6147)
+
+## Status
+Accepted
+
+## Date
+2026-06-10
+
+## Context
+
+IPv6-only clients cannot communicate directly with IPv4-only servers. In cloud environments where IPv6 migration is ongoing, many services only have A records (IPv4) but clients may attempt to connect via AAAA queries (IPv6). This creates a connectivity gap.
+
+DNS64 (RFC 6147) bridges this gap by synthesizing AAAA records from existing A records when an IPv6 query returns NODATA. The synthesized address embeds the IPv4 address into a designated IPv6 prefix (Well-Known Prefix `64:ff9b::/96`).
+
+## Decision
+
+Implement DNS64 synthesis in cloudDNS with the following characteristics:
+
+### Configuration
+- `DNS64_ENABLED=true` — Enable DNS64 synthesis
+- `DNS64_PREFIX=64:ff9b::` — Custom prefix (default: Well-Known Prefix)
+
+### Synthesis Logic
+When a query for AAAA returns NODATA (no AAAA records exist, but the zone exists):
+1. Query for A records at the same name
+2. If A records exist, synthesize AAAA records by embedding each IPv4 into the configured prefix
+3. Return synthesized AAAA records with NoError response code
+
+### Prefix Handling
+- Default: `64:ff9b::/96` (RFC 6147 Well-Known Prefix)
+- IPv4 address `w.x.y.z` becomes `64:ff9b::w.x.y.z`
+- Invalid prefixes (IPv4, nil) fall back to default
+
+### Caching
+- DNS64 responses use1-second TTL per RFC 6147 Section 5
+- Normal caching is bypassed for synthesized responses
+
+### Scope
+- DNS64 only applies to authoritative NODATA responses (not recursive resolution)
+- DNSSEC signing works normally on synthesized records
+
+## Consequences
+
+### Positive
+- IPv6-only clients can communicate with IPv4-only servers without NAT64 hardware
+- Transparent to clients — no configuration changes required on the client side
+- Improves IPv6 migration path in cloud environments
+
+### Negative
+- Additional query processing path for AAAA queries
+- Small TTL reduces cache effectiveness for synthesized records
+
+### Neutral
+- AAAA queries without A records are unaffected
+- Recursive resolution unchanged
+
+## Alternatives Considered
+
+### Alternative 1: NAT64 Hardware at Network Layer
+**Why rejected:** Requires dedicated hardware appliance, not software-defined, expensive for distributed deployments.
+
+### Alternative 2: CLient-Side DNS64
+**Why rejected:** Requires client configuration changes, not transparent, defeats purpose of centralized DNS server.
+
+## References
+- [RFC 6147 - DNS64: DNS Extensions for IPv6 Transition](https://datatracker.ietf.org/doc/html/rfc6147)
+- [RFC 6052 - IPv6 Addressing of IPv4/IPv6 Translators](https://datatracker.ietf.org/doc/html/rfc6052) (prefix format)

--- a/features.md
+++ b/features.md
@@ -33,6 +33,7 @@ Built-in orchestration for global Anycast networks using BGP.
 *   **HTTPS Records (RFC 9460)**: Service binding hints for HTTP-aware clients with Encrypted Client Hello (ECH) support.
 *   **Dynamic Updates (RFC 2136)**: Standardized dynamic record management.
 *   **IXFR (Incremental Zone Transfer)**: RFC 1995 compliant synchronization using transactional delta logging, with intelligent AXFR fallback.
+*   **DNS64 (RFC 6147)**: Synthesizes AAAA records from A records for IPv6-only clients communicating with IPv4-only servers.
 
 ## 6. Management & Security
 *   **Hexagonal Architecture**: Strict separation between core logic and infrastructure adapters.

--- a/internal/core/config/server.go
+++ b/internal/core/config/server.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"net"
 	"time"
 )
 
@@ -39,6 +40,16 @@ type ServerConfig struct {
 
 	// BGPNextHop is the next hop address for BGP announcements. Default: "127.0.0.1".
 	BGPNextHop string
+
+	// DNS64Enabled enables DNS64 synthesis (RFC 6147). Default: false.
+	DNS64Enabled bool
+
+	// DNS64Prefix is the IPv6 prefix used for DNS64 synthesis.
+	// Default: 64:ff9b::/96 (Well-Known Prefix per RFC 6147).
+	DNS64Prefix net.IP
+
+	// DNS64PrefixStr is the string form of the DNS64 prefix for env var parsing.
+	DNS64PrefixStr string
 }
 
 // DefaultServerConfig returns a ServerConfig with all values set to defaults.
@@ -53,5 +64,8 @@ func DefaultServerConfig() *ServerConfig {
 		BGPRouterID:             "127.0.0.1",
 		BGPListenPort:            179,
 		BGPNextHop:               "127.0.0.1",
+		DNS64Enabled:             false,
+		DNS64Prefix:              net.ParseIP("64:ff9b::"),
+		DNS64PrefixStr:           "64:ff9b::",
 	}
 }

--- a/internal/dns/packet/packet.go
+++ b/internal/dns/packet/packet.go
@@ -226,6 +226,9 @@ type DNSHeader struct {
 	Z               bool
 	RecursionAvailable bool
 
+	// DNS64Synthesized is set when the response contains synthesized AAAA records (RFC 6147).
+	DNS64Synthesized bool
+
 	// RFC 2136 (Dynamic Update) field renames:
 	// Questions -> ZOCOUNT (Number of zones)
 	// Answers -> PRCOUNT (Number of prerequisites)

--- a/internal/dns/server/dns64.go
+++ b/internal/dns/server/dns64.go
@@ -30,8 +30,14 @@ func (s *DNS64Synthesizer) embedIPv4(ipv4 net.IP) net.IP {
 	if ipv4 == nil {
 		return nil
 	}
+	// Validate prefix is a proper IPv6 address (not IPv4) with sufficient bits (/96 or shorter)
+	prefix := s.prefix
+	if prefix.To4() != nil || prefix.To16() == nil {
+		// Invalid prefix, use default
+		prefix = DefaultDNS64Prefix
+	}
 	ipv6 := make(net.IP, 16)
-	copy(ipv6, s.prefix)
+	copy(ipv6, prefix)
 	ipv6[12] = ipv4[0]
 	ipv6[13] = ipv4[1]
 	ipv6[14] = ipv4[2]

--- a/internal/dns/server/dns64.go
+++ b/internal/dns/server/dns64.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"net"
+
+	"github.com/poyrazK/cloudDNS/internal/dns/packet"
+)
+
+// DefaultDNS64Prefix is the Well-Known Prefix (WKP) per RFC 6147.
+var DefaultDNS64Prefix = net.ParseIP("64:ff9b::")
+
+// DNS64Synthesizer handles DNS64 AAAA record synthesis (RFC 6147).
+type DNS64Synthesizer struct {
+	prefix net.IP
+}
+
+// NewDNS64Synthesizer creates a new DNS64 synthesizer with the given prefix.
+// If prefix is nil, DefaultDNS64Prefix (64:ff9b::/96) is used.
+func NewDNS64Synthesizer(prefix net.IP) *DNS64Synthesizer {
+	if prefix == nil {
+		prefix = DefaultDNS64Prefix
+	}
+	return &DNS64Synthesizer{prefix: prefix}
+}
+
+// embedIPv4 embeds an IPv4 address into the DNS64 prefix.
+// w.x.y.z becomes 64:ff9b::w.x.y.z
+func (s *DNS64Synthesizer) embedIPv4(ipv4 net.IP) net.IP {
+	ipv4 = ipv4.To4()
+	if ipv4 == nil {
+		return nil
+	}
+	ipv6 := make(net.IP, 16)
+	copy(ipv6, s.prefix)
+	ipv6[12] = ipv4[0]
+	ipv6[13] = ipv4[1]
+	ipv6[14] = ipv4[2]
+	ipv6[15] = ipv4[3]
+	return ipv6
+}
+
+// SynthesizeAAAA synthesizes AAAA records from A records.
+// Each IPv4 address w.x.y.z becomes 64:ff9b::w.x.y.z
+// Returns the synthesized AAAA records with appropriate TTL.
+func (s *DNS64Synthesizer) SynthesizeAAAA(aRecords []packet.DNSRecord, queryName string, minTTL uint32) []packet.DNSRecord {
+	var aaaaRecords []packet.DNSRecord
+	for _, aRec := range aRecords {
+		if aRec.Type != packet.A {
+			continue
+		}
+		ipv6 := s.embedIPv4(aRec.IP)
+		if ipv6 == nil {
+			continue
+		}
+		aaaaRecords = append(aaaaRecords, packet.DNSRecord{
+			Name:  queryName,
+			Type:  packet.AAAA,
+			Class: aRec.Class,
+			TTL:   minTTL,
+			IP:    ipv6,
+		})
+	}
+	return aaaaRecords
+}
+
+// IsDNS64Applicable checks if DNS64 synthesis should be attempted.
+// Returns true only when:
+// - Query is for AAAA record type
+// - No AAAA records exist (NODATA)
+// - A records DO exist for the same name
+func (s *DNS64Synthesizer) IsDNS64Applicable(qType packet.QueryType, aaaaRecords, aRecords []packet.DNSRecord) bool {
+	if qType != packet.AAAA {
+		return false
+	}
+	if len(aaaaRecords) > 0 {
+		return false
+	}
+	if len(aRecords) == 0 {
+		return false
+	}
+	return true
+}

--- a/internal/dns/server/dns64_test.go
+++ b/internal/dns/server/dns64_test.go
@@ -1,0 +1,195 @@
+package server
+
+import (
+	"net"
+	"testing"
+
+	"github.com/poyrazK/cloudDNS/internal/dns/packet"
+)
+
+func TestDNS64Synthesizer_EmbedIPv4(t *testing.T) {
+	synth := NewDNS64Synthesizer(nil)
+
+	tests := []struct {
+		name     string
+		ipv4     string
+		expected string
+	}{
+		{"simple", "192.0.2.1", "64:ff9b::c000:201"},
+		{"zero", "0.0.0.0", "64:ff9b::0.0.0.0"},
+		{"max", "255.255.255.255", "64:ff9b::ffff:ffff"},
+		{"private", "10.0.0.1", "64:ff9b::a00:1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ipv4 := net.ParseIP(tt.ipv4)
+			ipv6 := synth.embedIPv4(ipv4)
+			expected := net.ParseIP(tt.expected)
+			if !ipv6.Equal(expected) {
+				t.Errorf("embedIPv4(%s) = %s, want %s", tt.ipv4, ipv6, expected)
+			}
+		})
+	}
+}
+
+func TestDNS64Synthesizer_EmbedIPv4_NotIPv4(t *testing.T) {
+	synth := NewDNS64Synthesizer(nil)
+	// IPv6 address should return nil
+	ipv6 := net.ParseIP("2001:db8::1")
+	result := synth.embedIPv4(ipv6)
+	if result != nil {
+		t.Errorf("embedIPv4(IPv6) = %s, want nil", result)
+	}
+}
+
+func TestDNS64Synthesizer_IsDNS64Applicable(t *testing.T) {
+	synth := NewDNS64Synthesizer(nil)
+
+	aRecord := packet.DNSRecord{
+		Name:  "example.com.",
+		Type:  packet.A,
+		Class: 1,
+		TTL:   300,
+		IP:    net.ParseIP("192.0.2.1"),
+	}
+
+	tests := []struct {
+		name        string
+		qType       packet.QueryType
+		aaaaRecords []packet.DNSRecord
+		aRecords    []packet.DNSRecord
+		want        bool
+	}{
+		{
+			name:        "applicable",
+			qType:       packet.AAAA,
+			aaaaRecords: nil,
+			aRecords:    []packet.DNSRecord{aRecord},
+			want:        true,
+		},
+		{
+			name:        "not_aaaa",
+			qType:       packet.A,
+			aaaaRecords: nil,
+			aRecords:    []packet.DNSRecord{aRecord},
+			want:        false,
+		},
+		{
+			name:        "has_aaaa",
+			qType:       packet.AAAA,
+			aaaaRecords: []packet.DNSRecord{{Name: "example.com.", Type: packet.AAAA}},
+			aRecords:    []packet.DNSRecord{aRecord},
+			want:        false,
+		},
+		{
+			name:        "no_a_records",
+			qType:       packet.AAAA,
+			aaaaRecords: nil,
+			aRecords:    nil,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := synth.IsDNS64Applicable(tt.qType, tt.aaaaRecords, tt.aRecords)
+			if got != tt.want {
+				t.Errorf("IsDNS64Applicable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDNS64Synthesizer_SynthesizeAAAA(t *testing.T) {
+	synth := NewDNS64Synthesizer(nil)
+
+	aRecords := []packet.DNSRecord{
+		{
+			Name:  "example.com.",
+			Type:  packet.A,
+			Class: 1,
+			TTL:   300,
+			IP:    net.ParseIP("192.0.2.1"),
+		},
+		{
+			Name:  "example.com.",
+			Type:  packet.A,
+			Class: 1,
+			TTL:   600,
+			IP:    net.ParseIP("192.0.2.2"),
+		},
+	}
+
+	aaaaRecords := synth.SynthesizeAAAA(aRecords, "example.com.", 300)
+
+	if len(aaaaRecords) != 2 {
+		t.Fatalf("expected 2 AAAA records, got %d", len(aaaaRecords))
+	}
+
+	expectedIPs := []string{"64:ff9b::c000:201", "64:ff9b::c000:202"}
+	for i, expected := range expectedIPs {
+		if !aaaaRecords[i].IP.Equal(net.ParseIP(expected)) {
+			t.Errorf("AAAA record %d = %s, want %s", i, aaaaRecords[i].IP, expected)
+		}
+		if aaaaRecords[i].Type != packet.AAAA {
+			t.Errorf("AAAA record %d type = %v, want AAAA", i, aaaaRecords[i].Type)
+		}
+		if aaaaRecords[i].TTL != 300 {
+			t.Errorf("AAAA record %d TTL = %d, want 300", i, aaaaRecords[i].TTL)
+		}
+	}
+}
+
+func TestDNS64Synthesizer_SynthesizeAAAA_IgnoresNonARecords(t *testing.T) {
+	synth := NewDNS64Synthesizer(nil)
+
+	mixedRecords := []packet.DNSRecord{
+		{
+			Name:  "example.com.",
+			Type:  packet.A,
+			Class: 1,
+			TTL:   300,
+			IP:    net.ParseIP("192.0.2.1"),
+		},
+		{
+			Name:  "example.com.",
+			Type:  packet.CNAME,
+			Class: 1,
+			TTL:   300,
+		},
+		{
+			Name:  "example.com.",
+			Type:  packet.AAAA,
+			Class: 1,
+			TTL:   300,
+			IP:    net.ParseIP("2001:db8::1"),
+		},
+	}
+
+	aaaaRecords := synth.SynthesizeAAAA(mixedRecords, "example.com.", 300)
+
+	// Should only synthesize from the single A record
+	if len(aaaaRecords) != 1 {
+		t.Fatalf("expected 1 AAAA record, got %d", len(aaaaRecords))
+	}
+
+	expectedIP := net.ParseIP("64:ff9b::c000:201")
+	if !aaaaRecords[0].IP.Equal(expectedIP) {
+		t.Errorf("AAAA record = %s, want %s", aaaaRecords[0].IP, expectedIP)
+	}
+}
+
+func TestDNS64Synthesizer_CustomPrefix(t *testing.T) {
+	customPrefix := net.ParseIP("2001:db8:64::")
+	synth := NewDNS64Synthesizer(customPrefix)
+
+	ipv4 := net.ParseIP("192.0.2.1")
+	ipv6 := synth.embedIPv4(ipv4)
+
+	// Should use custom prefix instead of default
+	expected := net.ParseIP("2001:db8:64::c000:201")
+	if !ipv6.Equal(expected) {
+		t.Errorf("embedIPv4 with custom prefix = %s, want %s", ipv6, expected)
+	}
+}

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1376,7 +1376,7 @@ func (s *Server) cacheResult(ctx context.Context, cacheKey string, resData []byt
 	}
 	var ttl uint32 = 300
 	// DNS64 synthesized responses should not be cached (or use very short TTL)
-	// per RFC 6147 Section 5. Use1 second TTL as a compromise.
+	// per RFC 6147 Section 5. Use 1 second TTL as a compromise.
 	if resp.Header.DNS64Synthesized {
 		ttl = 1
 	} else if len(resp.Answers) > 0 {

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -66,6 +66,12 @@ type Server struct {
 	RecursionEnabled bool
 	CookieSecret     []byte
 
+	// DNS64Enabled enables DNS64 synthesis (RFC 6147).
+	// When enabled and an AAAA query returns NODATA, the server synthesizes
+	// AAAA records from existing A records using the configured DNS64Prefix.
+	DNS64Enabled bool
+	DNS64Prefix  net.IP
+
 	// Testing/Chaos flags
 	SimulateDBLatency  time.Duration
 	NotifyPortOverride int
@@ -857,6 +863,11 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	// Handle NXDOMAIN / NoData / authoritative
 	if len(response.Answers) == 0 {
 		s.handleNxDomain(ctx, request, q, zone, dnssecOK, clientOPT, clientIP, response)
+
+		// DNS64 synthesis (RFC 6147) - only for authoritative NODATA
+		if s.DNS64Enabled && q.QType == packet.AAAA && zone != nil {
+			s.synthesizeDNS64(ctx, q, clientIP, response)
+		}
 	} else if zone != nil {
 		s.populateAuthorityAndAdditional(ctx, response, zone, clientIP)
 	}
@@ -1364,7 +1375,11 @@ func (s *Server) cacheResult(ctx context.Context, cacheKey string, resData []byt
 		return
 	}
 	var ttl uint32 = 300
-	if len(resp.Answers) > 0 {
+	// DNS64 synthesized responses should not be cached (or use very short TTL)
+	// per RFC 6147 Section 5. Use1 second TTL as a compromise.
+	if resp.Header.DNS64Synthesized {
+		ttl = 1
+	} else if len(resp.Answers) > 0 {
 		ttl = resp.Answers[0].TTL
 	} else if len(resp.Authorities) > 0 {
 		ttl = resp.Authorities[0].TTL
@@ -1386,3 +1401,33 @@ func (s *Server) cacheResult(ctx context.Context, cacheKey string, resData []byt
 	}
 }
 
+
+// synthesizeDNS64 performs DNS64 synthesis (RFC 6147).
+// Called when a query for AAAA returns NODATA but we have an authoritative zone.
+func (s *Server) synthesizeDNS64(ctx context.Context, q packet.DNSQuestion, clientIP string, resp *packet.DNSPacket) {
+	aRecords, err := s.Repo.GetRecords(ctx, q.Name, domain.TypeA, clientIP)
+	if err != nil || len(aRecords) == 0 {
+		return
+	}
+	var aPacketRecords []packet.DNSRecord
+	minTTL := uint32(300)
+	for _, rec := range aRecords {
+		if pRec, err := repository.ConvertDomainToPacketRecord(rec); err == nil {
+			aPacketRecords = append(aPacketRecords, pRec)
+			if rec.TTL < int(minTTL) {
+				minTTL = uint32(rec.TTL)
+			}
+		}
+	}
+	if len(aPacketRecords) == 0 {
+		return
+	}
+	synthesizer := NewDNS64Synthesizer(s.DNS64Prefix)
+	aaaaRecords := synthesizer.SynthesizeAAAA(aPacketRecords, q.Name, minTTL)
+	if len(aaaaRecords) > 0 {
+		resp.Answers = append(resp.Answers, aaaaRecords...)
+		resp.Header.ResCode = 0       // NoError instead of NXDOMAIN
+		resp.Header.AuthoritativeAnswer = true
+		resp.Header.DNS64Synthesized = true
+	}
+}


### PR DESCRIPTION
## Summary
- Add DNS64 configuration (DNS64_ENABLED, DNS64_PREFIX env vars)
- Implement DNS64 synthesizer that synthesizes AAAA records from A records using Well-Known Prefix (64:ff9b::/96)
- Integrate DNS64 synthesis into query flow for authoritative NODATA responses
- DNS64 responses use 1-second TTL per RFC 6147
- Add unit tests for synthesis logic

## Configuration
- `DNS64_ENABLED=true` - Enable DNS64 synthesis
- `DNS64_PREFIX=64:ff9b::` - Custom prefix (default: 64:ff9b::/96)

## Files Changed
- `internal/core/config/server.go` - DNS64 config fields
- `internal/dns/packet/packet.go` - DNS64Synthesized header flag
- `internal/dns/server/server.go` - synthesizeDNS64 method, handlePacket integration, cache TTL handling
- `internal/dns/server/dns64.go` - DNS64 synthesizer (NEW)
- `internal/dns/server/dns64_test.go` - Unit tests (NEW)