### PR TITLE
fix: add tenant_id to wildcard cache key for tenant isolation (#235)

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -902,6 +902,13 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	s.truncateIfNeeded(response, resBuffer, maxSize)
 	resData := resBuffer.Buf[:resBuffer.Position()]
 
+	// Issue #235: If wildcard resolution occurred, rebuild cache key with zone's tenantID
+	// to ensure proper tenant isolation (original cacheKey may have been built before
+	// we knew which zone would serve the wildcard match)
+	if source == "wildcard" && zone != nil && zone.TenantID != "" {
+		cacheKey = zone.TenantID + ":" + lowerName + ":" + strconv.Itoa(int(q.QType))
+	}
+
 	// Cache result
 	s.cacheResult(ctx, cacheKey, resData, response)
 


### PR DESCRIPTION
## Summary
- Add tenant_id to wildcard cache key to prevent cross-tenant data leaks (fixes #235)
- When wildcard resolution occurs, rebuild cache key with zone's tenantID to ensure proper tenant isolation

## Changes
- `internal/dns/server/server.go`: After wildcard resolution, if `source == "wildcard"` and zone has a tenantID, rebuild the cache key using `zone.TenantID` instead of the original tenant-aware key (which was built before we knew which zone would serve the wildcard match)

## Testing
- Build verified
- Existing tests pass