### PR TITLE
fix: stop debounceTimer on anycast manager shutdown (#222)

### DIFF
--- a/internal/core/services/anycast_manager.go
+++ b/internal/core/services/anycast_manager.go
@@ -70,6 +70,9 @@ func (m *AnycastManager) Start(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			m.logger.Info("shutting down anycast manager, withdrawing route")
+			if m.debounceTimer != nil {
+				m.debounceTimer.Stop()
+			}
 			if err := m.routing.Withdraw(ctx, m.vip); err != nil {
 				m.logger.Error("failed to withdraw BGP on shutdown", "error", err, "vip", m.vip)
 			}


### PR DESCRIPTION
## Summary
- Stop debounceTimer on anycast manager graceful shutdown (fixes #222)
- Prevents timer from firing after manager has shut down (sending on closed channel)

## Changes
- `internal/core/services/anycast_manager.go`: In `Start()` method's `ctx.Done()` branch, call `m.debounceTimer.Stop()` before `m.routing.Withdraw()`

## Testing
- Build verified
- Existing tests pass