### PR TITLE
fix: remove double-wrapping of BatchCreateRecords error in IXFR fallback (#253)

### DIFF
--- a/internal/dns/server/client.go
+++ b/internal/dns/server/client.go
@@ -214,7 +214,7 @@ func (s *Server) performIXFR(ctx context.Context, zone *domain.Zone, masterAddr 
 			return fmt.Errorf("AXFR fallback failed to clear zone: %w", err)
 		}
 		if err := s.Repo.BatchCreateRecords(ctx, newRecords); err != nil {
-			return fmt.Errorf("AXFR fallback failed to import records: %w", err)
+			return err // BatchCreateRecords already wraps errors, don't double-wrap
 		}
 		return nil
 	}


### PR DESCRIPTION
## Summary
- Remove double-wrapping of BatchCreateRecords error in IXFR fallback (fixes #253)
- BatchCreateRecords already wraps errors with context; double-wrapping loses error chain

## Changes
- `internal/dns/server/client.go`: Change `return fmt.Errorf("AXFR fallback failed to import records: %w", err)` to `return err` since BatchCreateRecords already provides context

## Testing
- Build verified
- Existing tests pass