### PR TITLE
fix: add max iterations cap to NSEC3 validation to prevent CPU exhaustion (#242)

### DIFF
--- a/internal/dns/packet/dnssec_verify.go
+++ b/internal/dns/packet/dnssec_verify.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -673,6 +674,14 @@ func ValidateNSEC3RecordFormat(nsec3 DNSRecord) error {
 	// RFC 5155 Section 3.2: hash algorithm must be 1 (SHA-1)
 	if nsec3.HashAlg != 1 {
 		return ErrNSEC3HashAlgoUnsupported
+	}
+
+	// RFC 5155 Section 10.3: Iterations should be limited to prevent DoS (CPU exhaustion).
+	// High iterations (e.g., 5000+) on deeply nested names causes expensive SHA-1 computation.
+	// Common legitimate values are < 100; we cap at 150 to allow margin.
+	const MaxNSEC3Iterations = 150
+	if nsec3.Iterations > MaxNSEC3Iterations {
+		return fmt.Errorf("dnssec: nsec3 iterations too high (%d)", nsec3.Iterations)
 	}
 
 	// Salt length must be <= 255 per RFC 5155

--- a/internal/dns/packet/dnssec_verify_test.go
+++ b/internal/dns/packet/dnssec_verify_test.go
@@ -1531,6 +1531,53 @@ func TestValidateNSEC3RecordFormat_NextHashTooLong(t *testing.T) {
 	}
 }
 
+// TestValidateNSEC3RecordFormat_IterationsTooHigh tests that NSEC3 records with iterations > 150 are rejected.
+func TestValidateNSEC3RecordFormat_IterationsTooHigh(t *testing.T) {
+	nsec3 := DNSRecord{
+		Type:       NSEC3,
+		HashAlg:    1,
+		Iterations: 200, // > 150, should be rejected
+		Salt:       []byte{0xAB, 0xCD},
+		NextHash:   make([]byte, 20),
+	}
+	err := ValidateNSEC3RecordFormat(nsec3)
+	if err == nil {
+		t.Error("Expected error for iterations > 150")
+	}
+	// Verify the error message contains iteration count for debugging
+	if err != nil && !strings.Contains(err.Error(), "nsec3 iterations too high") {
+		t.Errorf("Expected error message to mention 'nsec3 iterations too high', got: %v", err)
+	}
+}
+
+// TestValidateNSEC3RecordFormat_BoundaryValues tests boundary values around the iterations cap.
+func TestValidateNSEC3RecordFormat_BoundaryValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		iterations uint16
+		wantErr    bool
+	}{
+		{"150 is valid", 150, false},
+		{"151 is invalid", 151, true},
+		{"200 is invalid", 200, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nsec3 := DNSRecord{
+				Type:       NSEC3,
+				HashAlg:    1,
+				Iterations: tt.iterations,
+				Salt:       []byte{0xAB, 0xCD},
+				NextHash:   make([]byte, 20),
+			}
+			err := ValidateNSEC3RecordFormat(nsec3)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateNSEC3RecordFormat(iterations=%d) error = %v, wantErr %v", tt.iterations, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestBase32Decode tests NSEC3-specific base32 decoding.
 func TestBase32Decode(t *testing.T) {
 	// Known test vectors from NSEC3 hash examples


### PR DESCRIPTION
## Summary
- Add max iterations cap to NSEC3 record validation (fixes #242)
- Prevents CPU exhaustion DoS from high iteration counts (e.g., 5000+) on deeply nested names

## Changes
- `internal/dns/packet/dnssec_verify.go`: Add validation in `ValidateNSEC3RecordFormat` that rejects NSEC3 records with iterations > 150 (RFC 5155 Section 10.3)

## Testing
- Build verified
- Existing tests pass

## Related Issues
- Closes #242