### PR TITLE
fix: resolve GoBGP issues #251, #232, #231, #214

### DIFF
--- a/cmd/clouddns/main.go
+++ b/cmd/clouddns/main.go
@@ -306,10 +306,11 @@ func run(ctx context.Context) error {
 			}
 		}
 
-		// Configure RouterID and NextHop if provided
+		// Configure RouterID, NextHop, and peer password if provided
 		routerID := os.Getenv("BGP_ROUTER_ID")
 		nextHop := os.Getenv("BGP_NEXT_HOP")
-		routingAdapter.SetConfig(routerID, bgpListenPort, nextHop)
+		peerPassword := os.Getenv("BGP_PEER_PASSWORD")
+		routingAdapter.SetConfig(routerID, bgpListenPort, nextHop, peerPassword)
 
 		anycastDebounce := 5 * time.Second
 		if v := os.Getenv("ANYCAST_DEBOUNCE_SECS"); v != "" {

--- a/internal/adapters/routing/gobgp.go
+++ b/internal/adapters/routing/gobgp.go
@@ -34,11 +34,12 @@ type BGPBackend interface {
 // It tracks its goroutines for graceful shutdown and attempts peer reconnection
 // on disconnect.
 type GoBGPAdapter struct {
-	bgpServer  BGPBackend
-	logger     *slog.Logger
-	routerID   string
-	listenPort int32
-	nextHop    string
+	bgpServer    BGPBackend
+	logger       *slog.Logger
+	routerID     string
+	listenPort   int32
+	nextHop      string
+	peerPassword string
 
 	localASN uint32
 	peerASN  uint32
@@ -69,7 +70,7 @@ func NewGoBGPAdapter(logger *slog.Logger) *GoBGPAdapter {
 }
 
 // SetConfig updates the BGP configuration.
-func (a *GoBGPAdapter) SetConfig(routerID string, listenPort int32, nextHop string) {
+func (a *GoBGPAdapter) SetConfig(routerID string, listenPort int32, nextHop string, peerPassword string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if routerID != "" {
@@ -80,6 +81,9 @@ func (a *GoBGPAdapter) SetConfig(routerID string, listenPort int32, nextHop stri
 	}
 	if nextHop != "" {
 		a.nextHop = nextHop
+	}
+	if peerPassword != "" {
+		a.peerPassword = peerPassword
 	}
 }
 
@@ -138,6 +142,10 @@ func (a *GoBGPAdapter) addPeer(ctx context.Context, peerASN uint32, peerIP strin
 			PeerAsn:         peerASN,
 		},
 	}
+	// Apply MD5 password authentication if configured
+	if a.peerPassword != "" {
+		peer.Conf.AuthPassword = a.peerPassword
+	}
 	return a.bgpServer.AddPeer(ctx, &pb.AddPeerRequest{Peer: peer})
 }
 
@@ -183,12 +191,12 @@ func (a *GoBGPAdapter) Announce(_ context.Context, vip string) error {
 		Paths: []*apiutil.Path{path},
 	}
 
+	// Atomically update BGP and track VIP to ensure consistency
+	a.announcedMu.Lock()
 	if _, err := a.bgpServer.AddPath(req); err != nil {
+		a.announcedMu.Unlock()
 		return fmt.Errorf("failed to add path for vip %s: %w", vip, err)
 	}
-
-	// Track announced VIP for later withdrawal on Stop()
-	a.announcedMu.Lock()
 	a.announcedVIPs[vip] = true
 	a.announcedMu.Unlock()
 
@@ -236,12 +244,12 @@ func (a *GoBGPAdapter) Withdraw(_ context.Context, vip string) error {
 		},
 	}
 
+	// Atomically delete from BGP and remove from tracking
+	a.announcedMu.Lock()
 	if err := a.bgpServer.DeletePath(req); err != nil {
+		a.announcedMu.Unlock()
 		return fmt.Errorf("failed to delete path for vip %s: %w", vip, err)
 	}
-
-	// Remove from tracked VIPs
-	a.announcedMu.Lock()
 	delete(a.announcedVIPs, vip)
 	a.announcedMu.Unlock()
 
@@ -326,8 +334,17 @@ func (a *GoBGPAdapter) monitorPeer(ctx context.Context) {
 				} else {
 					a.logger.Warn("peer unhealthy, attempting reconnect", "peer", peerIP, "error", err)
 					// Restart BGP server and peer
-					a.mu.Lock()
+					// Note: must release mu before calling Stop() to avoid lock inversion deadlock.
+					// Stop() calls wg.Wait() which may block, and another goroutine calling Stop()
+					// would try to acquire mu, causing a deadlock.
+					a.mu.Unlock()
 					a.bgpServer.Stop()
+					a.mu.Lock()
+					// Check if Stop() was called while we released the lock (stopCh closed = shutdown requested)
+					if a.stopCh == nil {
+						a.mu.Unlock()
+						return
+					}
 					a.bgpServer = server.NewBgpServer()
 
 					global := &pb.Global{

--- a/internal/adapters/routing/gobgp_extra_test.go
+++ b/internal/adapters/routing/gobgp_extra_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestGoBGPAdapter_SetConfig(t *testing.T) {
 	adapter := NewGoBGPAdapter(nil)
-	adapter.SetConfig("1.2.3.4", 1790, "1.2.3.1")
+	adapter.SetConfig("1.2.3.4", 1790, "1.2.3.1", "")
 	
 	if adapter.routerID != "1.2.3.4" {
 		t.Errorf("routerID not set correctly")
@@ -21,7 +21,7 @@ func TestGoBGPAdapter_SetConfig(t *testing.T) {
 	}
 	
 	// Test partial update
-	adapter.SetConfig("", 0, "8.8.8.8")
+	adapter.SetConfig("", 0, "8.8.8.8", "")
 	if adapter.routerID != "1.2.3.4" {
 		t.Errorf("routerID should not have changed")
 	}

--- a/internal/adapters/routing/gobgp_extra_test.go
+++ b/internal/adapters/routing/gobgp_extra_test.go
@@ -2,14 +2,49 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
+
+	pb "github.com/osrg/gobgp/v4/api"
+	"github.com/osrg/gobgp/v4/pkg/apiutil"
 )
+
+// mockBGPBackendWithCapture captures AddPeer requests to verify AuthPassword
+type mockBGPBackendWithCapture struct {
+	failAddPath    bool
+	failDeletePath bool
+	failAddPeer    bool
+	lastAddPeerReq *pb.AddPeerRequest
+}
+
+func (m *mockBGPBackendWithCapture) Serve()                                                           {}
+func (m *mockBGPBackendWithCapture) Stop()                                                          {}
+func (m *mockBGPBackendWithCapture) StartBgp(_ context.Context, _ *pb.StartBgpRequest) error         { return nil }
+func (m *mockBGPBackendWithCapture) AddPath(_ apiutil.AddPathRequest) ([]apiutil.AddPathResponse, error) {
+	if m.failAddPath {
+		return nil, errors.New("add path failed")
+	}
+	return []apiutil.AddPathResponse{{}}, nil
+}
+func (m *mockBGPBackendWithCapture) DeletePath(_ apiutil.DeletePathRequest) error {
+	if m.failDeletePath {
+		return errors.New("delete path failed")
+	}
+	return nil
+}
+func (m *mockBGPBackendWithCapture) AddPeer(_ context.Context, r *pb.AddPeerRequest) error {
+	if m.failAddPeer {
+		return errors.New("add peer failed")
+	}
+	m.lastAddPeerReq = r
+	return nil
+}
 
 func TestGoBGPAdapter_SetConfig(t *testing.T) {
 	adapter := NewGoBGPAdapter(nil)
 	adapter.SetConfig("1.2.3.4", 1790, "1.2.3.1", "")
-	
+
 	if adapter.routerID != "1.2.3.4" {
 		t.Errorf("routerID not set correctly")
 	}
@@ -19,7 +54,7 @@ func TestGoBGPAdapter_SetConfig(t *testing.T) {
 	if adapter.nextHop != "1.2.3.1" {
 		t.Errorf("nextHop not set correctly")
 	}
-	
+
 	// Test partial update
 	adapter.SetConfig("", 0, "8.8.8.8", "")
 	if adapter.routerID != "1.2.3.4" {
@@ -27,6 +62,103 @@ func TestGoBGPAdapter_SetConfig(t *testing.T) {
 	}
 	if adapter.nextHop != "8.8.8.8" {
 		t.Errorf("nextHop not updated correctly")
+	}
+}
+
+func TestGoBGPAdapter_SetConfig_PeerPassword(t *testing.T) {
+	adapter := NewGoBGPAdapter(nil)
+	adapter.SetConfig("1.2.3.4", 1790, "1.2.3.1", "mysecretpassword")
+
+	if adapter.peerPassword != "mysecretpassword" {
+		t.Errorf("expected peerPassword to be set, got %q", adapter.peerPassword)
+	}
+
+	// Verify empty string does NOT overwrite existing password
+	adapter.SetConfig("", 0, "", "")
+	if adapter.peerPassword != "mysecretpassword" {
+		t.Errorf("expected peerPassword to remain after empty string update, got %q", adapter.peerPassword)
+	}
+}
+
+func TestGoBGPAdapter_Announce_AtomicTrackingOnFailure(t *testing.T) {
+	mock := &mockBGPBackendWithCapture{failAddPath: true}
+	adapter := &GoBGPAdapter{
+		bgpServer:     mock,
+		logger:        slog.Default(),
+		announcedVIPs: make(map[string]bool),
+	}
+
+	ctx := context.Background()
+	err := adapter.Announce(ctx, "1.1.1.1")
+	if err == nil {
+		t.Fatal("expected error from failed AddPath")
+	}
+
+	// VIP should NOT be tracked because AddPath failed (atomicity)
+	adapter.announcedMu.Lock()
+	if adapter.announcedVIPs["1.1.1.1"] {
+		t.Error("VIP should not be tracked after AddPath failure")
+	}
+	adapter.announcedMu.Unlock()
+}
+
+func TestGoBGPAdapter_Withdraw_AtomicTrackingOnFailure(t *testing.T) {
+	mock := &mockBGPBackendWithCapture{}
+	adapter := &GoBGPAdapter{
+		bgpServer:     mock,
+		logger:        slog.Default(),
+		announcedVIPs: make(map[string]bool),
+	}
+
+	ctx := context.Background()
+
+	// First announce successfully
+	if err := adapter.Announce(ctx, "1.1.1.1"); err != nil {
+		t.Fatalf("Announce failed: %v", err)
+	}
+
+	// Verify it's tracked
+	adapter.announcedMu.Lock()
+	if !adapter.announcedVIPs["1.1.1.1"] {
+		t.Fatal("VIP should be tracked after successful Announce")
+	}
+	adapter.announcedMu.Unlock()
+
+	// Now fail the withdraw
+	mock.failDeletePath = true
+	err := adapter.Withdraw(ctx, "1.1.1.1")
+	if err == nil {
+		t.Fatal("expected error from failed DeletePath")
+	}
+
+	// VIP should still be tracked because DeletePath failed (atomicity)
+	adapter.announcedMu.Lock()
+	if !adapter.announcedVIPs["1.1.1.1"] {
+		t.Error("VIP should still be tracked after DeletePath failure")
+	}
+	adapter.announcedMu.Unlock()
+}
+
+func TestGoBGPAdapter_PeerPasswordAppliedToAddPeer(t *testing.T) {
+	mock := &mockBGPBackendWithCapture{}
+	adapter := &GoBGPAdapter{
+		bgpServer:     mock,
+		logger:        slog.Default(),
+		peerPassword:  "secret123",
+		announcedVIPs: make(map[string]bool),
+	}
+
+	ctx := context.Background()
+	err := adapter.addPeer(ctx, 65002, "192.168.1.1")
+	if err != nil {
+		t.Fatalf("addPeer failed: %v", err)
+	}
+
+	if mock.lastAddPeerReq == nil {
+		t.Fatal("AddPeer was not called")
+	}
+	if mock.lastAddPeerReq.Peer.Conf.AuthPassword != "secret123" {
+		t.Errorf("expected AuthPassword 'secret123', got %q", mock.lastAddPeerReq.Peer.Conf.AuthPassword)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes 4 GoBGP issues in the BGP anycast integration layer:

- **#251 (Critical)**: Fix lock inversion deadlock in monitorPeer - release mu before calling Stop(), re-acquire after with nil check to prevent restart after shutdown
- **#232 (Medium)**: Make AddPath/DeletePath atomic with announcedVIPs tracking - wrap both operations under announcedMu lock
- **#231 & #214 (High)**: Add BGP MD5 password authentication support via peerPassword field and BGP_PEER_PASSWORD env var

## Changes

### internal/adapters/routing/gobgp.go
- Fix lock inversion: monitorPeer now releases mu before calling a.bgpServer.Stop(), then re-acquires and checks stopCh == nil to abort restart if Stop() was called
- Atomic tracking: Announce() and Withdraw() now hold announcedMu for the entire BGP operation + map update sequence
- MD5 auth: peerPassword field added to struct, applied as AuthPassword on peer configuration in addPeer()

### cmd/clouddns/main.go
- Added BGP_PEER_PASSWORD env var support, passed to SetConfig()

## Testing
- All existing routing tests pass
- New tests for atomicity, SetConfig, and peer password propagation
- Build compiles successfully

## Closes

Closes #251
Closes #232
Closes #231
Closes #214