### PR TITLE
fix: replace SetNoCopy with Set for L2->L1 cache to prevent data corruption (#202, #203)

### DIFF
--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -1230,7 +1230,7 @@ func (s *Server) checkCache(ctx context.Context, req *packet.DNSPacket, cacheKey
 		} else if remainingTTL > l1TTLCap {
 			remainingTTL = l1TTLCap
 		}
-		s.Cache.SetNoCopy(cacheKey, data, remainingTTL)
+		s.Cache.Set(cacheKey, data, remainingTTL)
 		lock.Unlock()
 		_ = sendFn(data)
 		return data


### PR DESCRIPTION
## Summary

Fixes L2→L1 cache data corruption where SetNoCopy was aliasing Redis's pooled connection buffer into L1 cache. When Redis reuses the connection, L1 entries are silently overwritten.

## Changes

### internal/dns/server/server.go:1233
- Changed `s.Cache.SetNoCopy(cacheKey, data, remainingTTL)` → `s.Cache.Set(cacheKey, data, remainingTTL)`
- `Set()` performs a defensive copy (`cache.go:148-149`), breaking the alias with Redis's buffer

## Impact

- **#202**: L1 cache entries silently corrupted when Redis connection reused
- **#203**: TXID mutation at lines 1219-1220 corrupts Redis connection state for subsequent requests

## Testing

- All cache tests pass: `go test -v -run Cache ./internal/dns/server/`
- Build compiles: `go build ./...`

## Closes

Closes #202
Closes #203