### PR TITLE
fix: resolve crypto issues #200, #226, #204

### DIFF
--- a/internal/core/services/health_monitor.go
+++ b/internal/core/services/health_monitor.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"net"
@@ -24,9 +23,8 @@ type HealthMonitor struct {
 
 // HealthMonitorOptions configures optional health monitor behavior.
 type HealthMonitorOptions struct {
-	InsecureSkipVerify   bool
-	HTTPTimeout          time.Duration
-	TCPTimeout           time.Duration
+	HTTPTimeout time.Duration
+	TCPTimeout  time.Duration
 }
 
 // NewHealthMonitor creates a new HealthMonitor with a default HTTP client.
@@ -42,11 +40,6 @@ func NewHealthMonitor(repo ports.DNSRepository, logger *slog.Logger, opts *Healt
 		}
 	}
 	client := &http.Client{Timeout: httpTimeout}
-	if opts != nil && opts.InsecureSkipVerify {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-	}
 	return &HealthMonitor{
 		repo:      repo,
 		logger:    logger,

--- a/internal/core/services/health_monitor_test.go
+++ b/internal/core/services/health_monitor_test.go
@@ -147,17 +147,3 @@ func TestHealthMonitor_Start(t *testing.T) {
 	// Verify no probe was attempted
 	repo.AssertNotCalled(t, "GetRecordsToProbeStreaming")
 }
-
-func TestHealthMonitor_InsecureSkipVerify(t *testing.T) {
-	m := NewHealthMonitor(nil, nil, &HealthMonitorOptions{InsecureSkipVerify: true})
-	if m.client.Transport == nil {
-		t.Fatal("expected custom transport with InsecureSkipVerify")
-	}
-	tr, ok := m.client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatalf("expected *http.Transport, got %T", m.client.Transport)
-	}
-	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
-		t.Fatal("expected TLSClientConfig.InsecureSkipVerify to be true")
-	}
-}

--- a/internal/dns/packet/dnssec_verify.go
+++ b/internal/dns/packet/dnssec_verify.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/hmac"
 	"crypto/rsa"
 	"crypto/sha256"
 	"errors"
@@ -546,8 +547,8 @@ func VerifyDNSKEYMatchesDS(dnskey DNSRecord, ds DNSRecord) (bool, error) {
 		return false, ErrAlgorithmMismatch
 	}
 
-	// Compare digests
-	if string(computedDS.Digest) != string(ds.Digest) {
+	// Compare digests using constant-time comparison to prevent timing attacks
+	if !hmac.Equal(computedDS.Digest, ds.Digest) {
 		return false, errors.New("dnssec: DS digest mismatch")
 	}
 

--- a/internal/dns/packet/tsig.go
+++ b/internal/dns/packet/tsig.go
@@ -3,7 +3,7 @@ package packet
 
 import (
 	"crypto/hmac"
-	"crypto/md5" // #nosec G501
+	"crypto/sha256" // #nosec G505
 	"errors"
 	"time"
 )
@@ -37,7 +37,7 @@ func (p *DNSPacket) VerifyTSIG(rawBuffer []byte, tsigStart int, secret []byte) e
 	}
 
 	// 3. Compute HMAC
-	h := hmac.New(md5.New, secret)
+	h := hmac.New(sha256.New, secret)
 	
 	// Create a copy of the buffer before TSIG and adjust ARCOUNT
 	// Header is 12 bytes, ARCOUNT is at offset 10 (2 bytes)
@@ -83,14 +83,14 @@ func (p *DNSPacket) SignTSIG(buffer *BytePacketBuffer, keyName string, secret []
 		Type:          TSIG,
 		Class:         255, // ANY
 		TTL:           0,
-		AlgorithmName: "hmac-md5.sig-alg.reg.int.",
+		AlgorithmName: "hmac-sha256.sig-alg.reg.int.",
 		TimeSigned:    (func() uint64 { u := time.Now().Unix(); if u < 0 { return 0 }; return uint64(u) })(),
 		Fudge:         300,
 		OriginalID:    p.Header.ID,
 	}
 
 	// 2. Compute MAC
-	h := hmac.New(md5.New, secret)
+	h := hmac.New(sha256.New, secret)
 	
 	// Write current buffer content (packet without TSIG)
 	h.Write(buffer.Buf[:buffer.Position()])


### PR DESCRIPTION
## Summary

Fixes 3 crypto security issues:

- **#200 (High)**: Replace MD5 with SHA-256 for TSIG HMAC computation. MD5 is cryptographically broken for HMAC purposes (RFC 8624 recommends HMAC-SHA256).

- **#226 (High)**: Use `hmac.Equal()` for constant-time DS digest comparison to prevent timing attacks.

- **#204 (High)**: Remove `InsecureSkipVerify` option from `HealthMonitorOptions`. TLS certificate validation should never be disabled in production.

## Changes

### internal/dns/packet/tsig.go
- Replace `crypto/md5` import with `crypto/sha256`
- Change `hmac.New(md5.New, secret)` → `hmac.New(sha256.New, secret)` in both `VerifyTSIG` and `SignTSIG`
- Update algorithm name from `"hmac-md5.sig-alg.reg.int."` to `"hmac-sha256.sig-alg.reg.int."`

### internal/dns/packet/dnssec_verify.go
- Add `crypto/hmac` import
- Change `string(computedDS.Digest) != string(ds.Digest)` → `!hmac.Equal(computedDS.Digest, ds.Digest)`

### internal/core/services/health_monitor.go
- Remove `InsecureSkipVerify` field from `HealthMonitorOptions`
- Remove `crypto/tls` import (no longer needed)
- Remove custom Transport with InsecureSkipVerify

### internal/core/services/health_monitor_test.go
- Remove `TestHealthMonitor_InsecureSkipVerify` test

## Testing

- All TSIG tests pass
- All DNSSEC tests pass
- All HealthMonitor tests pass
- Build compiles successfully

## Closes

Closes #200
Closes #226
Closes #204