### PR TITLE
fix: add DNS cookie validation and fix empty IP in server cookie generation (#207, #230)

### DIFF
--- a/internal/dns/server/dnssec.go
+++ b/internal/dns/server/dnssec.go
@@ -26,6 +26,17 @@ func (s *Server) generateServerCookie(clientCookie []byte, clientIP string) []by
 	return h.Sum(nil)[:16] // Return 16 bytes of server cookie
 }
 
+// validateCookie validates a DNS cookie per RFC 7873/9013.
+// It regenerates the expected server cookie using the presenting clientIP
+// and compares it with the received serverCookie using constant-time comparison.
+func (s *Server) validateCookie(clientCookie, serverCookie []byte, clientIP string) bool {
+	if len(s.CookieSecret) == 0 || len(clientCookie) != 8 || len(serverCookie) != 16 {
+		return false
+	}
+	expected := s.generateServerCookie(clientCookie, clientIP)
+	return hmac.Equal(expected, serverCookie)
+}
+
 // padResponse pads a DNS response to a multiple of blockSize for privacy (RFC 9276).
 func (s *Server) padResponse(response *packet.DNSPacket, blockSize int) {
 	// Find OPT record

--- a/internal/dns/server/rfc7873_test.go
+++ b/internal/dns/server/rfc7873_test.go
@@ -193,3 +193,30 @@ func TestValidateCookie_NoSecret(t *testing.T) {
 		t.Errorf("validateCookie() = true, want false when no CookieSecret")
 	}
 }
+
+func TestGenerateServerCookie(t *testing.T) {
+	srv := NewServer(":0", &mockServerRepo{}, nil)
+	srv.CookieSecret = make([]byte, 32)
+	_, _ = crand.Read(srv.CookieSecret)
+
+	clientCookie := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	tests := []struct {
+		name     string
+		clientIP string
+	}{
+		{"IPv4", "192.168.1.1"},
+		{"IPv6", "::1"},
+		{"empty IP", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serverCookie := srv.generateServerCookie(clientCookie, tt.clientIP)
+			if len(serverCookie) != 16 {
+				t.Errorf("generateServerCookie() returned %d bytes, want 16", len(serverCookie))
+			}
+		})
+	}
+}
+

--- a/internal/dns/server/rfc7873_test.go
+++ b/internal/dns/server/rfc7873_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	crand "crypto/rand"
 	"context"
 	"net"
 	"testing"
@@ -96,4 +97,99 @@ func TestDNSCookies_RFC7873(t *testing.T) {
 	}
 
 	// 3. Subsequent query with the same cookie should be accepted (verified manually by coverage or looking at logs)
+}
+
+func TestValidateCookie(t *testing.T) {
+	srv := NewServer(":0", &mockServerRepo{}, nil)
+	srv.CookieSecret = make([]byte, 32)
+	_, _ = crand.Read(srv.CookieSecret)
+
+	tests := []struct {
+		name       string
+		clientIP   string
+		wantValid  bool
+	}{
+		{
+			name:      "valid cookie",
+			clientIP:  "192.168.1.1",
+			wantValid: true,
+		},
+		{
+			name:      "different IP",
+			clientIP:  "10.0.0.1",
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Generate a valid client cookie
+			clientCookie := make([]byte, 8)
+			_, _ = crand.Read(clientCookie)
+
+			// Generate server cookie with the correct IP
+			serverCookie := srv.generateServerCookie(clientCookie, tt.clientIP)
+
+			// Validate should pass for correct IP
+			valid := srv.validateCookie(clientCookie, serverCookie, tt.clientIP)
+			if !valid {
+				t.Errorf("validateCookie() = false, want true for IP %s", tt.clientIP)
+			}
+
+			// Validate should fail for different IP
+			invalidIP := "10.10.10.10"
+			valid = srv.validateCookie(clientCookie, serverCookie, invalidIP)
+			if valid {
+				t.Errorf("validateCookie() = true, want false for IP %s", invalidIP)
+			}
+		})
+	}
+}
+
+func TestValidateCookie_InvalidInputs(t *testing.T) {
+	srv := NewServer(":0", &mockServerRepo{}, nil)
+	srv.CookieSecret = make([]byte, 32)
+	_, _ = crand.Read(srv.CookieSecret)
+
+	tests := []struct {
+		name        string
+		clientC     []byte
+		serverC     []byte
+		clientIP    string
+	}{
+		{
+			name:     "wrong client cookie length",
+			clientC:  []byte{1, 2, 3},  // 3 bytes, not 8
+			serverC:  make([]byte, 16),
+			clientIP: "192.168.1.1",
+		},
+		{
+			name:     "wrong server cookie length",
+			clientC:  make([]byte, 8),
+			serverC:  []byte{1, 2, 3},  // 3 bytes, not 16
+			clientIP: "192.168.1.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := srv.validateCookie(tt.clientC, tt.serverC, tt.clientIP)
+			if valid {
+				t.Errorf("validateCookie() = true, want false for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestValidateCookie_NoSecret(t *testing.T) {
+	srv := NewServer(":0", &mockServerRepo{}, nil)
+	// CookieSecret is nil/empty by default
+
+	clientCookie := make([]byte, 8)
+	serverCookie := make([]byte, 16)
+
+	valid := srv.validateCookie(clientCookie, serverCookie, "192.168.1.1")
+	if valid {
+		t.Errorf("validateCookie() = true, want false when no CookieSecret")
+	}
 }

--- a/internal/dns/server/server.go
+++ b/internal/dns/server/server.go
@@ -842,8 +842,27 @@ func (s *Server) handlePacket(ctx context.Context, data []byte, srcAddr interfac
 	// EDNS0 processing
 	clientOPT, maxSize, dnssecOK, nsidRequested, clientCookie, paddingRequested := s.processEDNS0(request)
 
+	// Validate cookie if present (RFC 7873) — cookie is 24 bytes (8 client + 16 server)
+	if len(clientCookie) == 24 {
+		if !s.validateCookie(clientCookie[:8], clientCookie[8:], clientIP) {
+			s.Logger.Warn("cookie validation failed, possible replay", "clientIP", clientIP)
+			// Return BADCOOKIE error response
+			errResp := packet.NewDNSPacket()
+			errResp.Header.ID = request.Header.ID
+			errResp.Header.Response = true
+			errResp.Header.ResCode = 16 // BADCOOKIE
+			errResp.Questions = append(errResp.Questions, q)
+			buf := packet.GetBuffer()
+			_ = errResp.Write(buf)
+			respBytes := buf.Buf[:buf.Position()]
+			packet.PutBuffer(buf)
+			_ = sendFn(respBytes)
+			return nil
+		}
+	}
+
 	// Build response skeleton
-	response := s.newResponseSkeleton(request, q, clientOPT, dnssecOK, nsidRequested, clientCookie)
+	response := s.newResponseSkeleton(request, q, clientOPT, dnssecOK, nsidRequested, clientCookie, clientIP)
 	source := "local"
 
 	// Guard against nil repository
@@ -1151,7 +1170,7 @@ func (s *Server) processEDNS0(req *packet.DNSPacket) (*packet.DNSRecord, int, bo
 }
 
 // newResponseSkeleton creates the response packet with header fields set.
-func (s *Server) newResponseSkeleton(req *packet.DNSPacket, q packet.DNSQuestion, clientOPT *packet.DNSRecord, dnssecOK, nsidRequested bool, clientCookie []byte) *packet.DNSPacket {
+func (s *Server) newResponseSkeleton(req *packet.DNSPacket, q packet.DNSQuestion, clientOPT *packet.DNSRecord, dnssecOK, nsidRequested bool, clientCookie []byte, clientIP string) *packet.DNSPacket {
 	response := packet.NewDNSPacket()
 	response.Header.ID = req.Header.ID
 	response.Header.Response = true
@@ -1173,7 +1192,7 @@ func (s *Server) newResponseSkeleton(req *packet.DNSPacket, q packet.DNSQuestion
 			opt.SetOption(packet.EdnsOptionNSID, []byte(s.NodeID))
 		}
 		if len(clientCookie) == 8 {
-			serverCookie := s.generateServerCookie(clientCookie[:8], "")
+			serverCookie := s.generateServerCookie(clientCookie[:8], clientIP)
 			opt.SetOption(packet.EdnsOptionCookie, append(clientCookie[:8], serverCookie...))
 		}
 		response.Resources = append(response.Resources, opt)


### PR DESCRIPTION
## Summary

Fixes 2 DNS Cookie security issues:

- **#230 (Critical)**: Server cookie was generated with empty string instead of client IP, violating RFC 7873
- **#207 (Critical)**: Cookie could be replayed from different IP — no validation performed

## Changes

### internal/dns/server/dnssec.go
- Added `validateCookie()` method for RFC 7873/9013 cookie validation
- Uses constant-time comparison (hmac.Equal) to prevent timing attacks

### internal/dns/server/server.go
- **Issue #230 fix**: Threaded clientIP through to newResponseSkeleton and now passes actual IP to generateServerCookie instead of empty string
- **Issue #207 fix**: Added cookie validation in handlePacket after EDNS0 processing
  - If cookie is 24 bytes (8 client + 16 server), validates using validateCookie
  - On validation failure, returns BADCOOKIE (Rcode 16) error response

## Testing

- All server tests pass
- Build succeeds

## Closes

Closes #207
Closes #230